### PR TITLE
Docs: shrink README, split install mechanics into docs/install.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,55 +98,6 @@ Each new task forks from the previous task's Codex thread via `thread/fork`. The
 
 Codex is shipping. Everything in "coming next" is on the same architectural surface — each new model is a new adapter binary + one line in the spawn shim's routing table. See [docs/roadmap.md](docs/roadmap.md).
 
-## How installation works
-
-One command writes two env vars to `~/.claude/settings.json`:
-
-```json
-{
-  "env": {
-    "CLAUDE_CODE_TEAMMATE_COMMAND": "/absolute/path/to/claude-anyteam-spawn-shim",
-    "CLAUDE_ANYTEAM_BINARY": "/absolute/path/to/claude-anyteam"
-  }
-}
-```
-
-When Agent Teams mode spawns a teammate, Claude Code invokes `$CLAUDE_CODE_TEAMMATE_COMMAND` (the shim) instead of native `claude`. The shim inspects the agent name:
-
-- `codex-*` → dispatches to the `claude-anyteam` adapter (Codex)
-- Anything else → forwards to native `claude` (unchanged)
-
-Every step is reversible. `claude-anyteam uninstall` cleanly removes the env vars.
-
-## Other install paths
-
-```bash
-# via uv directly (if you already have uv + Python)
-uv tool install claude-anyteam && claude-anyteam install
-
-# via Claude Code plugin (self-heals settings on every session)
-claude plugin marketplace add JonathanRosado/claude-anyteam
-claude plugin install claude-anyteam@claude-anyteam
-```
-
-All paths write the same settings. Pick whichever fits your workflow.
-
-Installing the plugin also gives Claude a plugin-provided `/claude-anyteam:help` skill, so the assistant can explain that `codex-<name>` teammates route to Codex, that `~/.claude/settings.json` is already wired by the installer, and that the GitHub repo is the source of truth.
-
-## Launch a teammate directly
-
-For headless and persistent background adapters (run across multiple Claude Code sessions):
-
-```bash
-setsid nohup claude-anyteam \
-  --team my-team --name codex-alice \
-  --cwd /path/to/workspace \
-  --model gpt-5.5 --effort high \
-  </dev/null >/tmp/codex-alice.stdout 2>/tmp/codex-alice.stderr & disown
-```
-
-This mode is fully messageable (inbox, task claim, peer replies) but does NOT render in Claude Code's TUI presence line — TUI visibility requires the leader-spawn path via the shim (above). Useful when you want the adapter running continuously regardless of the Claude Code session lifecycle.
-
 ## Requirements
 
 - Python 3.12+
@@ -157,6 +108,7 @@ This mode is fully messageable (inbox, task claim, peer replies) but does NOT re
 
 ## Docs
 
+- [Install](docs/install.md) — how the installer wires Claude Code, alternative install methods, headless launches
 - [Architecture](docs/architecture.md) — how the adapter integrates with Claude Code's team protocol
 - [Roadmap](docs/roadmap.md) — supported today vs coming next, contribution pointers
 - [Configuration](docs/configuration.md) — CLI flags, env vars, advanced modes

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Your Claude Code session orchestrates. External models execute. No chat-wrapper 
 ## Quickstart
 
 ```bash
-npx --yes --package claude-anyteam claude-anyteam-setup
+npx --yes claude-anyteam
 ```
 
 That's the entire install. The installer:

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,64 @@
+# Install
+
+The quickstart in the [README](../README.md#quickstart) is the normal path:
+
+```bash
+npx --yes claude-anyteam
+```
+
+That's the entire install. The installer:
+
+- Detects `python3` and installs `uv` if missing (non-interactive, no shell profile edits)
+- Installs the `claude-anyteam` Python tool via `uv tool install`
+- Verifies a terminal multiplexer (tmux or psmux) is on PATH — see [configuration.md](configuration.md#teammate-display-mode) for install commands
+- Writes the Claude Code hook (`CLAUDE_CODE_TEAMMATE_COMMAND`) and binary path to `~/.claude/settings.json`
+- Sets `teammateMode="tmux"` in `~/.claude.json` (prompts before overwriting a non-default value)
+
+## How installation works
+
+One command writes two env vars to `~/.claude/settings.json`:
+
+```json
+{
+  "env": {
+    "CLAUDE_CODE_TEAMMATE_COMMAND": "/absolute/path/to/claude-anyteam-spawn-shim",
+    "CLAUDE_ANYTEAM_BINARY": "/absolute/path/to/claude-anyteam"
+  }
+}
+```
+
+When Agent Teams mode spawns a teammate, Claude Code invokes `$CLAUDE_CODE_TEAMMATE_COMMAND` (the shim) instead of native `claude`. The shim inspects the agent name:
+
+- `codex-*` → dispatches to the `claude-anyteam` adapter (Codex)
+- Anything else → forwards to native `claude` (unchanged)
+
+Every step is reversible. `claude-anyteam uninstall` cleanly removes the env vars and reverts `teammateMode` to whatever was there before (or removes it entirely if the install added it).
+
+## Alternative install methods
+
+```bash
+# via uv directly (if you already have uv + Python)
+uv tool install claude-anyteam && claude-anyteam install
+
+# via Claude Code plugin (self-heals settings on every session)
+claude plugin marketplace add JonathanRosado/claude-anyteam
+claude plugin install claude-anyteam@claude-anyteam
+```
+
+All paths write the same settings. Pick whichever fits your workflow.
+
+Installing the plugin also gives Claude a plugin-provided `/claude-anyteam:help` skill, so the assistant can explain that `codex-<name>` teammates route to Codex, that `~/.claude/settings.json` is already wired by the installer, and that the GitHub repo is the source of truth.
+
+## Headless / persistent teammates
+
+For headless and persistent background adapters (run across multiple Claude Code sessions):
+
+```bash
+setsid nohup claude-anyteam \
+  --team my-team --name codex-alice \
+  --cwd /path/to/workspace \
+  --model gpt-5.5 --effort high \
+  </dev/null >/tmp/codex-alice.stdout 2>/tmp/codex-alice.stderr & disown
+```
+
+This mode is fully messageable (inbox, task claim, peer replies) but does NOT render in Claude Code's TUI presence line — TUI visibility requires the leader-spawn path via the shim. Useful when you want the adapter running continuously regardless of the Claude Code session lifecycle.

--- a/npm/bin/setup.js
+++ b/npm/bin/setup.js
@@ -58,7 +58,7 @@ function parseArgs(argv) {
 
 function usage() {
   return [
-    'Usage: claude-anyteam-setup [--settings-path <path>] [--postinstall]',
+    'Usage: npx --yes claude-anyteam [--settings-path <path>] [--postinstall]',
     '',
     'Installs uv if needed, installs the Python claude-anyteam tool, writes',
     '~/.claude/settings.json with absolute launcher paths, and registers the',
@@ -116,7 +116,7 @@ function trimmedDetails(error) {
 
 function postinstallHint(error) {
   const reason = trimmedDetails(error) || error.message;
-  console.warn(`claude-anyteam: automatic setup skipped (${reason.split(/\r?\n/, 1)[0]}). Run npx --yes --package claude-anyteam claude-anyteam-setup to finish.`);
+  console.warn(`claude-anyteam: automatic setup skipped (${reason.split(/\r?\n/, 1)[0]}). Run npx --yes claude-anyteam to finish.`);
 }
 
 function claudePluginManualSummary() {
@@ -200,7 +200,7 @@ async function main() {
     }
     printFailure('PYTHON 3 REQUIRED', [
       `${theme.symbols.error} ${theme.heading('claude-anyteam needs python3 before anything else can happen.')}`,
-      `${theme.symbols.info} Install Python 3, then rerun ${theme.accent('npx --yes --package claude-anyteam claude-anyteam-setup')}.`,
+      `${theme.symbols.info} Install Python 3, then rerun ${theme.accent('npx --yes claude-anyteam')}.`,
       '',
       ...instructions.map((line) => `${theme.symbols.info} ${line}`),
     ]);
@@ -221,7 +221,7 @@ async function main() {
       }
       printFailure('UV NOT INSTALLED', [
         `${theme.symbols.warn} ${theme.heading('uv is required to install the Python claude-anyteam tool.')}`,
-        `${theme.symbols.info} Install it manually, then rerun ${theme.accent('npx --yes --package claude-anyteam claude-anyteam-setup')}.`,
+        `${theme.symbols.info} Install it manually, then rerun ${theme.accent('npx --yes claude-anyteam')}.`,
         '',
         ...manualInstallLines().map((line) => `${theme.symbols.info} ${line}`),
       ]);


### PR DESCRIPTION
## Summary

- Move three implementation-detail sections out of README.md into a new `docs/install.md`:
  - `## How installation works` (env var JSON + shim routing explanation)
  - `## Other install paths` (uv-direct, Claude Code plugin)
  - `## Launch a teammate directly` (headless `setsid nohup` pattern)
- README now sticks to marketing + quickstart + requirements + doc links. The Docs list gains an `[Install](docs/install.md)` entry.
- Shorten the quickstart from `npx --yes --package claude-anyteam claude-anyteam-setup` to `npx --yes claude-anyteam`. `npm/package.json` already declares both `claude-anyteam` and `claude-anyteam-setup` as bin entries pointing at `bin/setup.js`, and `setup.js` has no argv[0] / name-based branching (`parseArgs(process.argv.slice(2))` consumes flags only).
- Update the four `npx --yes --package claude-anyteam claude-anyteam-setup` strings in `npm/bin/setup.js` (Usage line for `--help`, postinstall skip warning, python3-missing failure hint, uv-declined failure hint) so error messages match what the README tells users to type.

## Test plan

- [x] `npx --yes claude-anyteam --help` against the published 0.2.0 package prints the usage line and exits 0.
- [x] `node --check npm/bin/setup.js` passes (syntax).
- [x] Full Python test suite: 222 passed, no regressions (same as PR #1 baseline).
- [x] README renders as marketing + quickstart + requirements + docs (verified locally).
- [x] `docs/install.md` covers every sentence that left README; no content lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)