### PR TITLE
Refresh Claude Code plugin on every npx run

### DIFF
--- a/npm/bin/setup.js
+++ b/npm/bin/setup.js
@@ -27,6 +27,10 @@ const CLAUDE_PLUGIN_SPEC = `${CLAUDE_PLUGIN_MARKETPLACE_NAME}@${CLAUDE_PLUGIN_MA
 const CLAUDE_PLUGIN_MANUAL_COMMANDS = [
   formatCommand('claude', ['plugin', 'marketplace', 'add', CLAUDE_PLUGIN_MARKETPLACE_SOURCE]),
   formatCommand('claude', ['plugin', 'install', CLAUDE_PLUGIN_SPEC]),
+  // Idempotent when already up-to-date; pulls the latest manifest otherwise.
+  // Running it on every install is how re-runs of the installer pick up new
+  // skill content without forcing the user to uninstall by hand.
+  formatCommand('claude', ['plugin', 'update', CLAUDE_PLUGIN_SPEC]),
 ];
 const CLAUDE_PLUGIN_MARKETPLACE_ALREADY_EXISTS = /\balready (?:on disk|exists)\b/i;
 const CLAUDE_PLUGIN_ALREADY_INSTALLED = /\balready installed\b/i;
@@ -201,19 +205,31 @@ async function runClaudePluginCommand(claudePath, args, alreadyPattern) {
   return { verified: alreadyPattern.test(combined) };
 }
 
+// Run `install` then `update` on every invocation so a re-run of
+// `npx --yes claude-anyteam` picks up the latest plugin manifest (and its
+// cached skills). `install` is a no-op when the plugin is already present;
+// `update` is idempotent when already on the latest version and pulls the
+// newer manifest otherwise. Together they cover fresh and upgrade paths
+// without a destructive uninstall step.
 async function registerClaudePlugin({ claudePath }) {
-  const marketplace = await runClaudePluginCommand(
+  await runClaudePluginCommand(
     claudePath,
     ['plugin', 'marketplace', 'add', CLAUDE_PLUGIN_MARKETPLACE_SOURCE],
     CLAUDE_PLUGIN_MARKETPLACE_ALREADY_EXISTS,
   );
-  const plugin = await runClaudePluginCommand(
+  await runClaudePluginCommand(
     claudePath,
     ['plugin', 'install', CLAUDE_PLUGIN_SPEC],
     CLAUDE_PLUGIN_ALREADY_INSTALLED,
   );
-  const status = marketplace.verified && plugin.verified ? 'verified' : 'installed';
-  return { status, summary: status };
+  await runClaudePluginCommand(
+    claudePath,
+    ['plugin', 'update', CLAUDE_PLUGIN_SPEC],
+    // Exits 0 on "already at the latest version" — no tolerance pattern
+    // needed. Any non-zero here is a genuine update failure.
+    /^$/,
+  );
+  return { status: 'refreshed', summary: 'installed + checked for updates' };
 }
 
 async function main() {

--- a/tests/test_npm_package.py
+++ b/tests/test_npm_package.py
@@ -88,6 +88,25 @@ def test_setup_delegates_to_python_installer() -> None:
     assert 'TEAMMATE_BINARY_KEY' not in setup_source
 
 
+def test_setup_refreshes_plugin_on_every_run() -> None:
+    """Re-running `npx --yes claude-anyteam` must pick up newer plugin versions.
+
+    Fails if someone drops the `claude plugin update` call in
+    registerClaudePlugin() — without it, a user who installed at v0.3.0 and
+    re-runs the installer after a new release is silently stuck on the old
+    cached manifest (the bug this test guards against).
+    """
+    setup_source = (NPM_DIR / 'bin' / 'setup.js').read_text(encoding='utf-8')
+
+    assert "'plugin', 'install', CLAUDE_PLUGIN_SPEC" in setup_source, (
+        'setup.js must still `claude plugin install` to cover the fresh-install path'
+    )
+    assert "'plugin', 'update', CLAUDE_PLUGIN_SPEC" in setup_source, (
+        'setup.js must `claude plugin update` on every run so re-runs pull the '
+        'latest manifest; without this, cached skills go stale'
+    )
+
+
 def test_npm_detect_logic_keeps_uv_tool_resolution_deterministic() -> None:
     detect_source = (NPM_DIR / 'lib' / 'detect.js').read_text(encoding='utf-8')
 


### PR DESCRIPTION
## Summary

- `registerClaudePlugin()` now runs `claude plugin install` + `claude plugin update` on every invocation. Previously it accepted "already installed" as success without forcing a refresh, so re-running `npx --yes claude-anyteam` after a plugin bump left the user stuck on the cached older skill content (the exact bug that broke today's demo of the hardened help skill).
- `claude plugin update` is idempotent: exit 0 with "already at the latest version" when up-to-date; pulls the newer manifest otherwise. Cleaner than an uninstall+install cycle (no destructive step, no brief window where the plugin is gone).
- Manual fallback commands shown when `claude` is off PATH now include the `update` step too, so the manual path stays parity with the automated one.
- New regression test `test_setup_refreshes_plugin_on_every_run` fails if either the `install` or `update` call disappears from `setup.js`.

## Test plan

- [x] `uv run pytest -q` — 239 passing locally
- [x] `claude plugin update claude-anyteam@claude-anyteam` verified to exit 0 when already at latest
- [ ] After merge + next release, verify `npx --yes claude-anyteam` on a machine with an older plugin cached refreshes the skill content without manual uninstall

🤖 Generated with [Claude Code](https://claude.com/claude-code)