### PR TITLE
Warn on missing or outdated codex-cli during install

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ That's the entire install. The installer:
 
 - Detects `python3` and installs `uv` if missing (non-interactive, no shell profile edits)
 - Installs the `claude-anyteam` Python tool via `uv tool install`
-- Runs `claude-anyteam install` (verifies tmux/psmux, writes `~/.claude/settings.json` + `~/.claude.json`, records install-state for symmetric uninstall)
+- Runs `claude-anyteam install` (verifies tmux/psmux, probes for the OpenAI Codex CLI and warns if it's missing or below 0.120, writes `~/.claude/settings.json` + `~/.claude.json`, records install-state for symmetric uninstall)
 
 Restart Claude Code, enable Agent Teams mode, and create a teammate named `codex-<anything>`:
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -12,6 +12,7 @@ That's the entire install. The npm installer:
 - Installs the `claude-anyteam` Python tool via `uv tool install`
 - Delegates the config writes to `claude-anyteam install --assume-yes`, which:
   - Verifies a terminal multiplexer (tmux or psmux) is on PATH — see [configuration.md](configuration.md#teammate-display-mode) for install commands
+  - Checks whether the OpenAI Codex CLI (`codex`) is on PATH and at version 0.120+. If it's missing or below the floor, prints a warning with install/upgrade instructions and a `codex` sign-in hint — but **does not** block the install (codex-* teammates need it at runtime, not at install time). If `codex` is present but its version can't be parsed, the installer falls back to a plain "Detected Codex CLI at …" line and proceeds without a warning. If both tmux and `codex` are missing, both warnings are emitted together before the tmux halt
   - Writes the Claude Code hook (`CLAUDE_CODE_TEAMMATE_COMMAND`) and binary path to `~/.claude/settings.json`
   - Sets `teammateMode="tmux"` in `~/.claude.json` (prompts before overwriting a non-default value)
   - Records what it changed in `~/.claude/plugins/data/claude-anyteam-claude-anyteam/install-state.json` so uninstall can cleanly reverse it

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,6 +1,6 @@
 # claude-anyteam (npm installer)
 
-A Node-powered bootstrap for the Python `claude-anyteam` tool. The npm package installs uv + the Python tool, then delegates the `~/.claude/settings.json` + `~/.claude.json` writes to `claude-anyteam install` so the Python installer is the single source of truth for tmux/psmux prereq checks, teammateMode handling, and install-state tracking.
+A Node-powered bootstrap for the Python `claude-anyteam` tool. The npm package installs uv + the Python tool, then delegates the `~/.claude/settings.json` + `~/.claude.json` writes to `claude-anyteam install` so the Python installer is the single source of truth for prereq checks (tmux/psmux required, Codex CLI 0.120+ warned-if-missing), teammateMode handling, and install-state tracking.
 
 ## Quick start
 
@@ -20,7 +20,7 @@ The setup flow shows the banner immediately, checks `python3`, installs `uv` if 
 2. checks for `python3`
 3. installs `uv` automatically if it is missing
 4. installs `claude-anyteam` with `uv tool install`, or reuses an existing install if it is already available
-5. runs `uv tool run --from claude-anyteam claude-anyteam install --assume-yes` — the Python installer verifies a terminal multiplexer (tmux or psmux) is on PATH, writes `~/.claude/settings.json` + `~/.claude.json`, and records an install-state file for symmetric uninstall
+5. runs `uv tool run --from claude-anyteam claude-anyteam install --assume-yes` — the Python installer verifies a terminal multiplexer (tmux or psmux) is on PATH, probes for the OpenAI Codex CLI (non-blocking warning if missing or below 0.120), writes `~/.claude/settings.json` + `~/.claude.json`, and records an install-state file for symmetric uninstall
 6. best-effort installs the `claude-anyteam` Claude Code plugin (or reports the exact manual commands if `claude` is unavailable)
 
 If the Python tool is already present in uv's tool bin directory, setup reuses it and re-runs `claude-anyteam install` (idempotent).

--- a/npm/bin/setup.js
+++ b/npm/bin/setup.js
@@ -62,8 +62,8 @@ function usage() {
     '',
     'Installs uv if needed, installs the Python claude-anyteam tool, delegates',
     'the ~/.claude/settings.json + ~/.claude.json writes to the Python installer',
-    '(which also verifies tmux/psmux is on PATH), and registers the Claude Code',
-    'plugin when the claude CLI is available on PATH.',
+    '(which verifies tmux/psmux on PATH and probes for the Codex CLI 0.120+),',
+    'and registers the Claude Code plugin when the claude CLI is available on PATH.',
   ].join('\n');
 }
 
@@ -337,7 +337,7 @@ async function main() {
   // status lines to stdout, and overlaying a spinner would fight with that output.
   if (!silent) {
     console.log('');
-    console.log(`${theme.symbols.info} ${theme.heading('Running claude-anyteam install (Python)')} ${theme.muted('— tmux prereq check, ~/.claude/settings.json, ~/.claude.json, install-state.json')}`);
+    console.log(`${theme.symbols.info} ${theme.heading('Running claude-anyteam install (Python)')} ${theme.muted('— tmux + Codex CLI prereq checks, ~/.claude/settings.json, ~/.claude.json, install-state.json')}`);
   }
   let installerResult;
   try {

--- a/src/claude_anyteam/installer.py
+++ b/src/claude_anyteam/installer.py
@@ -13,7 +13,9 @@ import contextlib
 import copy
 import json
 import os
+import re
 import shutil
+import subprocess
 import sys
 import tempfile
 from dataclasses import dataclass, field
@@ -67,6 +69,20 @@ class PrereqCheck:
 
 
 @dataclass(frozen=True)
+class CodexCliCheck:
+    """Result of probing for the OpenAI Codex CLI on PATH.
+
+    codex-cli is required at runtime for codex-* teammates but is NOT a hard
+    install prereq — users may install claude-anyteam first and add codex later.
+    """
+
+    found: bool
+    path: Path | None
+    version: str | None  # parsed version token (e.g. "0.124.0"); None if unparseable
+    raw_output: str | None  # raw `codex --version` stdout, retained for debugging
+
+
+@dataclass(frozen=True)
 class TeammateModeResult:
     """Outcome of install_teammate_mode()."""
 
@@ -102,6 +118,7 @@ class InstallResult:
     removed_legacy_keys: tuple[str, ...] = ()
     prereq: PrereqCheck | None = None
     teammate_mode: TeammateModeResult | None = None
+    codex_cli: CodexCliCheck | None = None
 
     @property
     def changed_anything(self) -> bool:
@@ -428,6 +445,126 @@ def _install_instructions(platform: str) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Codex CLI prereq check (informational — non-blocking)
+# ---------------------------------------------------------------------------
+
+CODEX_CLI_BINARY = "codex"
+CODEX_CLI_INSTALL_COMMAND = "npm i -g @openai/codex"
+CODEX_CLI_DOCS_URL = "https://github.com/openai/codex#getting-started"
+CODEX_CLI_MIN_VERSION: tuple[int, int, int] = (0, 120, 0)
+CODEX_CLI_VERSION_TIMEOUT_S = 5
+
+# Accepts semver-ish tokens like "0.124.0", "0.124", or "0.124.0-rc1". Rejects
+# garbage ("12abc"), leading-v prefixes ("v0.124.0"), and trailing junk.
+_CODEX_VERSION_TOKEN_RE = re.compile(
+    r"^(?P<major>\d+)\.(?P<minor>\d+)(?:\.(?P<patch>\d+))?(?:[-+][A-Za-z0-9.\-]+)?$"
+)
+
+
+def _parse_codex_version(raw: str) -> str | None:
+    for token in raw.split():
+        if _CODEX_VERSION_TOKEN_RE.match(token):
+            return token
+    return None
+
+
+def _parse_version_tuple(version: str | None) -> tuple[int, int, int] | None:
+    if version is None:
+        return None
+    match = _CODEX_VERSION_TOKEN_RE.match(version)
+    if match is None:
+        return None
+    major = int(match.group("major"))
+    minor = int(match.group("minor"))
+    patch = int(match.group("patch") or 0)
+    return (major, minor, patch)
+
+
+def _min_version_str() -> str:
+    return ".".join(str(part) for part in CODEX_CLI_MIN_VERSION)
+
+
+def _codex_meets_minimum(check: CodexCliCheck) -> bool | None:
+    """True if detected version ≥ floor, False if below, None if unknown/unparseable."""
+    if not check.found:
+        return None
+    parsed = _parse_version_tuple(check.version)
+    if parsed is None:
+        return None
+    return parsed >= CODEX_CLI_MIN_VERSION
+
+
+def _check_codex_cli() -> CodexCliCheck:
+    found_path = shutil.which(CODEX_CLI_BINARY)
+    if not found_path:
+        return CodexCliCheck(found=False, path=None, version=None, raw_output=None)
+
+    resolved = Path(found_path).resolve()
+    raw: str | None = None
+    version: str | None = None
+    try:
+        completed = subprocess.run(
+            [str(resolved), "--version"],
+            capture_output=True,
+            text=True,
+            timeout=CODEX_CLI_VERSION_TIMEOUT_S,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        completed = None
+
+    if completed is not None and completed.returncode == 0:
+        raw = (completed.stdout or "").strip() or None
+        if raw:
+            version = _parse_codex_version(raw)
+
+    return CodexCliCheck(found=True, path=resolved, version=version, raw_output=raw)
+
+
+def _codex_cli_warning(check: CodexCliCheck) -> str | None:
+    """Warning text for the codex-cli check, or None when no warning applies.
+
+    Two warning branches — missing and below-floor — each include the install
+    command, docs link, and the `codex` sign-in hint so users aren't blindsided
+    by an auth prompt the first time a codex-* teammate launches.
+
+    Returns None for both the "present and at-or-above floor" and "present but
+    version unparseable" cases. Parse-fail falls back to a presence-only line
+    (emitted by the caller); we don't synthesize a warning when we can't
+    actually confirm the floor was violated.
+    """
+    min_version = _min_version_str()
+    signin_hint = f"  After installing, run `{CODEX_CLI_BINARY}` once to sign in."
+    docs_line = f"  Setup guide: {CODEX_CLI_DOCS_URL}"
+
+    if not check.found:
+        return (
+            f"Warning: the OpenAI Codex CLI (`{CODEX_CLI_BINARY}`) was not found on PATH.\n"
+            f"  claude-anyteam is installed, but codex-* teammates will fail to launch\n"
+            f"  until Codex is installed. Add it with:\n"
+            f"    {CODEX_CLI_INSTALL_COMMAND}\n"
+            f"{signin_hint}\n"
+            f"{docs_line}"
+        )
+
+    meets = _codex_meets_minimum(check)
+    if meets is False:
+        return (
+            f"Warning: detected Codex CLI {check.version} at {check.path}, but\n"
+            f"  claude-anyteam requires {min_version} or newer. Upgrade with:\n"
+            f"    {CODEX_CLI_INSTALL_COMMAND}\n"
+            f"{signin_hint}\n"
+            f"{docs_line}"
+        )
+
+    # Found but version unparseable → fall back to presence-only acknowledgment;
+    # don't block on a parse miss, don't fabricate a scary warning when we can't
+    # confirm the floor either way.
+    return None
+
+
+
+# ---------------------------------------------------------------------------
 # teammateMode install/uninstall
 # ---------------------------------------------------------------------------
 
@@ -437,6 +574,7 @@ def install_teammate_mode(
     state_path: Path,
     prompt_fn: Callable[[str], bool],
     settings_file_created_by_anyteam: bool = False,
+    codex_cli: CodexCliCheck | None = None,
 ) -> TeammateModeResult:
     """Ensures ~/.claude.json has teammateMode='tmux', recording what we did in state.
 
@@ -460,7 +598,7 @@ def install_teammate_mode(
         )
 
     def _build_state(original: str | None, set_by: bool) -> dict[str, Any]:
-        return {
+        state: dict[str, Any] = {
             "schema_version": STATE_SCHEMA_VERSION,
             "teammateMode_original": original,
             "teammateMode_set_by_anyteam": set_by,
@@ -469,6 +607,10 @@ def install_teammate_mode(
             "settings_file_created_by_anyteam": bool(settings_file_created_by_anyteam),
             "claude_json_created_by_anyteam": bool(claude_json_created_by_anyteam),
         }
+        if codex_cli is not None:
+            state["codex_cli_found"] = bool(codex_cli.found)
+            state["codex_cli_version"] = codex_cli.version
+        return state
 
     # Case 1: absent.
     if current is None:
@@ -657,6 +799,7 @@ def install(
     state_path: Path | str | None = None,
     prompt_fn: Callable[[str], bool] | None = None,
     prereq_check_fn: Callable[[], PrereqCheck] | None = None,
+    codex_cli_check_fn: Callable[[], CodexCliCheck] | None = None,
 ) -> InstallResult:
     """Full install: prereq check → env block write → teammateMode update.
 
@@ -670,15 +813,25 @@ def install(
     does not pass --assume-yes will fail loudly rather than hang; real TTY
     prompting is handled in cli.py.
     """
+    # Collect BOTH prereqs before deciding to halt, so a user missing tmux AND
+    # codex-cli sees a single combined report instead of fixing tmux first then
+    # re-running only to hit a second surprise warning.
     checker = prereq_check_fn if prereq_check_fn is not None else _check_terminal_multiplexer
+    codex_checker = codex_cli_check_fn if codex_cli_check_fn is not None else _check_codex_cli
     prereq = checker()
+    codex_cli = codex_checker()
+
     if not prereq.found:
-        raise InstallError(
+        message = (
             "claude-anyteam requires a terminal multiplexer on PATH; none was found.\n"
             "Install one of:\n"
             f"{_install_instructions(prereq.platform)}\n"
             "After installing, re-run `claude-anyteam install`."
         )
+        codex_warning = _codex_cli_warning(codex_cli)
+        if codex_warning is not None:
+            message = f"{message}\n\nAdditionally:\n{codex_warning}"
+        raise InstallError(message)
 
     paths = discover_managed_paths(
         settings_path=settings_path,
@@ -729,6 +882,7 @@ def install(
             state_path=resolved_state_path,
             prompt_fn=effective_prompt,
             settings_file_created_by_anyteam=not existed,
+            codex_cli=codex_cli,
         )
     except InstallError:
         _rollback_env_block(
@@ -746,6 +900,7 @@ def install(
         removed_legacy_keys=tuple(removed_legacy),
         prereq=prereq,
         teammate_mode=mode_result,
+        codex_cli=codex_cli,
     )
 
 
@@ -921,6 +1076,18 @@ def format_install_message(result: InstallResult) -> str:
                 )
         else:
             lines.append(f"{TEAMMATE_MODE_KEY} already \"tmux\" in {mode.claude_json_path}; no change")
+
+    codex_cli = result.codex_cli
+    if codex_cli is not None:
+        warning = _codex_cli_warning(codex_cli)
+        if warning is not None:
+            lines.append(warning)
+        elif codex_cli.found:
+            if codex_cli.version:
+                lines.append(f"Detected Codex CLI {codex_cli.version} at {codex_cli.path}")
+            else:
+                # Parse-fail branch: presence-only acknowledgment.
+                lines.append(f"Detected Codex CLI at {codex_cli.path}")
 
     lines.append("Restart Claude Code for the changes to take effect.")
     if not result.changed_anything:

--- a/tests/test_install_command.py
+++ b/tests/test_install_command.py
@@ -283,6 +283,8 @@ def test_install_writes_teammate_mode_when_absent(tmp_path: Path, monkeypatch, c
         "teammateMode_set_by_anyteam": True,
         "settings_file_created_by_anyteam": True,
         "claude_json_created_by_anyteam": True,
+        "codex_cli_found": False,
+        "codex_cli_version": None,
     }
 
     stdout = capsys.readouterr().out
@@ -316,6 +318,8 @@ def test_install_is_noop_when_teammate_mode_already_tmux(tmp_path: Path, monkeyp
         "teammateMode_set_by_anyteam": False,
         "settings_file_created_by_anyteam": True,  # we did create settings.json
         "claude_json_created_by_anyteam": False,  # claude.json was pre-existing
+        "codex_cli_found": False,
+        "codex_cli_version": None,
     }
 
     stdout = capsys.readouterr().out
@@ -363,6 +367,8 @@ def test_install_prompts_and_overwrites_auto_when_accepted(tmp_path: Path, monke
         "teammateMode_set_by_anyteam": True,
         "settings_file_created_by_anyteam": True,  # we created settings.json (no pre-existing)
         "claude_json_created_by_anyteam": False,  # claude.json was pre-existing
+        "codex_cli_found": False,
+        "codex_cli_version": None,
     }
 
 
@@ -928,3 +934,355 @@ def test_uninstall_is_idempotent(tmp_path: Path, monkeypatch):
     assert cli_mod.main(_uninstall_argv(settings_path, claude_json_path, state_path)) == 0
     # Second uninstall: everything already gone; should still return 0, not raise.
     assert cli_mod.main(_uninstall_argv(settings_path, claude_json_path, state_path)) == 0
+
+
+# ---------------------------------------------------------------------------
+# Codex CLI prereq check (informational — non-blocking)
+# ---------------------------------------------------------------------------
+
+def _install_with_codex_stub(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    codex_cli: installer_mod.CodexCliCheck,
+) -> tuple[installer_mod.InstallResult, Path, Path]:
+    settings_path, claude_json_path, state_path, bin_dir = _fresh_paths(tmp_path)
+    codex_binary = _make_executable(bin_dir / "claude-anyteam")
+    _make_executable(bin_dir / "claude-anyteam-spawn-shim")
+
+    _stub_prereq_found(monkeypatch)
+    monkeypatch.setattr(installer_mod.shutil, "which", lambda name: None)
+
+    result = installer_mod.install(
+        settings_path=settings_path,
+        claude_json_path=claude_json_path,
+        state_path=state_path,
+        argv0=str(codex_binary),
+        prompt_fn=lambda _current: True,
+        codex_cli_check_fn=lambda: codex_cli,
+    )
+    return result, claude_json_path, state_path
+
+
+def test_install_detects_codex_cli_when_present(tmp_path: Path, monkeypatch):
+    codex_cli = installer_mod.CodexCliCheck(
+        found=True,
+        path=Path("/usr/local/bin/codex"),
+        version="0.124.0",
+        raw_output="codex-cli 0.124.0",
+    )
+    result, _claude_json_path, state_path = _install_with_codex_stub(tmp_path, monkeypatch, codex_cli)
+
+    assert result.codex_cli is not None
+    assert result.codex_cli.found is True
+    assert result.codex_cli.version == "0.124.0"
+
+    message = installer_mod.format_install_message(result)
+    assert "Detected Codex CLI 0.124.0 at /usr/local/bin/codex" in message
+    assert "Warning" not in message
+
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    assert state["codex_cli_found"] is True
+    assert state["codex_cli_version"] == "0.124.0"
+
+
+def test_install_warns_when_codex_cli_missing_but_still_succeeds(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+):
+    settings_path, claude_json_path, state_path, bin_dir = _fresh_paths(tmp_path)
+    codex_binary = _make_executable(bin_dir / "claude-anyteam")
+    _make_executable(bin_dir / "claude-anyteam-spawn-shim")
+
+    _stub_prereq_found(monkeypatch)
+    monkeypatch.setattr(installer_mod.shutil, "which", lambda name: None)
+    monkeypatch.setattr(
+        installer_mod,
+        "_check_codex_cli",
+        lambda: installer_mod.CodexCliCheck(
+            found=False, path=None, version=None, raw_output=None
+        ),
+    )
+    monkeypatch.setattr(cli_mod.sys, "argv", [str(codex_binary)])
+
+    exit_code = cli_mod.main(
+        _install_argv(settings_path, claude_json_path, state_path, "--assume-yes")
+    )
+    assert exit_code == 0, "missing codex-cli must not block install"
+
+    stdout = capsys.readouterr().out
+    assert "Warning: the OpenAI Codex CLI (`codex`) was not found on PATH." in stdout
+    assert "npm i -g @openai/codex" in stdout
+    assert "https://github.com/openai/codex" in stdout
+
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    assert state["codex_cli_found"] is False
+    assert state["codex_cli_version"] is None
+
+
+def test_install_handles_codex_version_parse_failure(tmp_path: Path, monkeypatch):
+    """Parse-fail falls back to presence-only — no warning, don't block on a parse miss."""
+    codex_cli = installer_mod.CodexCliCheck(
+        found=True,
+        path=Path("/usr/local/bin/codex"),
+        version=None,
+        raw_output="weird unexpected output",
+    )
+    result, _claude_json_path, state_path = _install_with_codex_stub(tmp_path, monkeypatch, codex_cli)
+
+    assert result.codex_cli is not None
+    assert result.codex_cli.found is True
+    assert result.codex_cli.version is None
+
+    message = installer_mod.format_install_message(result)
+    assert "Detected Codex CLI at /usr/local/bin/codex" in message
+    assert "Warning" not in message, "parse-fail must not emit a scary warning"
+
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    assert state["codex_cli_found"] is True
+    assert state["codex_cli_version"] is None
+
+
+def test_install_warns_when_codex_cli_below_floor(tmp_path: Path, monkeypatch):
+    codex_cli = installer_mod.CodexCliCheck(
+        found=True,
+        path=Path("/usr/local/bin/codex"),
+        version="0.118.0",
+        raw_output="codex-cli 0.118.0",
+    )
+    result, _claude_json_path, state_path = _install_with_codex_stub(tmp_path, monkeypatch, codex_cli)
+
+    message = installer_mod.format_install_message(result)
+    assert "Warning: detected Codex CLI 0.118.0" in message
+    assert "requires 0.120" in message
+    assert installer_mod.CODEX_CLI_INSTALL_COMMAND in message
+    assert "run `codex` once to sign in" in message
+    assert installer_mod.CODEX_CLI_DOCS_URL in message
+
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    assert state["codex_cli_found"] is True
+    assert state["codex_cli_version"] == "0.118.0", (
+        "state records the detected fact, not the floor comparison"
+    )
+
+
+def test_install_accepts_codex_cli_exactly_at_floor(tmp_path: Path, monkeypatch):
+    codex_cli = installer_mod.CodexCliCheck(
+        found=True,
+        path=Path("/usr/local/bin/codex"),
+        version="0.120.0",
+        raw_output="codex-cli 0.120.0",
+    )
+    result, _claude_json_path, _state_path = _install_with_codex_stub(tmp_path, monkeypatch, codex_cli)
+
+    message = installer_mod.format_install_message(result)
+    assert "Detected Codex CLI 0.120.0" in message
+    assert "Warning" not in message
+
+
+def test_install_combines_tmux_and_codex_warnings_on_tmux_halt(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+):
+    """User missing BOTH tmux and codex-cli should see both warnings at once."""
+    settings_path, claude_json_path, state_path, bin_dir = _fresh_paths(tmp_path)
+    _make_executable(bin_dir / "claude-anyteam")
+    _make_executable(bin_dir / "claude-anyteam-spawn-shim")
+
+    _stub_prereq_missing(monkeypatch, platform="linux")
+    monkeypatch.setattr(installer_mod.shutil, "which", lambda name: None)
+    monkeypatch.setattr(
+        installer_mod,
+        "_check_codex_cli",
+        lambda: installer_mod.CodexCliCheck(
+            found=False, path=None, version=None, raw_output=None
+        ),
+    )
+    monkeypatch.setattr(cli_mod.sys, "argv", [str(bin_dir / "claude-anyteam")])
+
+    exit_code = cli_mod.main(_install_argv(settings_path, claude_json_path, state_path))
+    assert exit_code != 0
+
+    err = capsys.readouterr().err
+    assert "requires a terminal multiplexer" in err
+    assert "sudo apt install tmux" in err
+    assert "Additionally:" in err
+    assert "Codex CLI (`codex`) was not found" in err
+
+
+def test_parse_codex_version_rejects_garbage_tokens():
+    # Direct unit coverage for the reviewer-requested branch: weird strings
+    # must parse to None rather than returning a bogus token.
+    for bad in (
+        "weird unexpected output",
+        "12abc",
+        "v0.124.0",  # leading-v prefix
+        "0..1",
+        "",
+        "0",  # major-only, not semver-ish enough
+        "codex-cli unknown",
+    ):
+        assert installer_mod._parse_codex_version(bad) is None, f"expected None for {bad!r}"
+
+
+def test_parse_codex_version_accepts_various_valid_shapes():
+    cases = {
+        "codex-cli 0.124.0": "0.124.0",
+        "codex-cli 0.120": "0.120",
+        "Codex 1.2.3-rc1": "1.2.3-rc1",
+        "codex 10.20.30": "10.20.30",
+    }
+    for raw, expected in cases.items():
+        assert installer_mod._parse_codex_version(raw) == expected, f"{raw!r} → {expected!r}"
+
+
+def test_parse_codex_version_picks_correct_token_from_noisy_output():
+    # Regression: the v1 "first token starting with a digit" heuristic would
+    # report "0" here. The tightened regex must skip "0" / "errors" / headings
+    # and land on "0.124.0".
+    noisy = "0 errors — codex-cli 0.124.0 (release build)"
+    assert installer_mod._parse_codex_version(noisy) == "0.124.0"
+
+
+def test_check_codex_cli_falls_back_when_subprocess_stdout_unparseable(
+    monkeypatch,
+    tmp_path: Path,
+):
+    """Real `_check_codex_cli()` parse-fail branch: returncode=0 + unparseable stdout.
+
+    Covers the branch the reviewer flagged as previously only exercised via a
+    pre-built `CodexCliCheck` fixture.
+    """
+    fake_codex = tmp_path / "codex"
+    fake_codex.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    fake_codex.chmod(0o755)
+
+    monkeypatch.setattr(installer_mod.shutil, "which", lambda _name: str(fake_codex))
+
+    class _Completed:
+        returncode = 0
+        stdout = "weird unexpected output\n"
+        stderr = ""
+
+    def _fake_run(*_args, **_kwargs):
+        return _Completed()
+
+    monkeypatch.setattr(installer_mod.subprocess, "run", _fake_run)
+
+    result = installer_mod._check_codex_cli()
+    assert result.found is True
+    assert result.version is None, "unparseable stdout must leave version=None"
+    assert result.raw_output == "weird unexpected output"
+
+
+def test_codex_meets_minimum_branches():
+    def _mk(version: str | None) -> installer_mod.CodexCliCheck:
+        return installer_mod.CodexCliCheck(
+            found=version is not None,
+            path=Path("/usr/local/bin/codex") if version is not None else None,
+            version=version,
+            raw_output=None,
+        )
+
+    assert installer_mod._codex_meets_minimum(_mk("0.120.0")) is True
+    assert installer_mod._codex_meets_minimum(_mk("0.124.0")) is True
+    assert installer_mod._codex_meets_minimum(_mk("1.0.0")) is True
+    assert installer_mod._codex_meets_minimum(_mk("0.119.999")) is False
+    assert installer_mod._codex_meets_minimum(_mk("0.0.1")) is False
+    assert installer_mod._codex_meets_minimum(_mk(None)) is None
+    # Not-found: meets_minimum returns None (there's nothing to compare).
+    assert (
+        installer_mod._codex_meets_minimum(
+            installer_mod.CodexCliCheck(found=False, path=None, version=None, raw_output=None)
+        )
+        is None
+    )
+
+
+def test_check_codex_cli_returns_missing_when_not_on_path(monkeypatch):
+    monkeypatch.setattr(installer_mod.shutil, "which", lambda _name: None)
+    result = installer_mod._check_codex_cli()
+    assert result.found is False
+    assert result.path is None
+    assert result.version is None
+    assert result.raw_output is None
+
+
+def test_check_codex_cli_parses_version_from_subprocess(monkeypatch, tmp_path: Path):
+    fake_codex = tmp_path / "codex"
+    fake_codex.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    fake_codex.chmod(0o755)
+
+    monkeypatch.setattr(installer_mod.shutil, "which", lambda _name: str(fake_codex))
+
+    class _Completed:
+        returncode = 0
+        stdout = "codex-cli 0.124.0\n"
+        stderr = ""
+
+    def _fake_run(*_args, **_kwargs):
+        return _Completed()
+
+    monkeypatch.setattr(installer_mod.subprocess, "run", _fake_run)
+
+    result = installer_mod._check_codex_cli()
+    assert result.found is True
+    assert result.version == "0.124.0"
+    assert result.raw_output == "codex-cli 0.124.0"
+
+
+def test_check_codex_cli_survives_subprocess_timeout(monkeypatch, tmp_path: Path):
+    fake_codex = tmp_path / "codex"
+    fake_codex.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    fake_codex.chmod(0o755)
+
+    monkeypatch.setattr(installer_mod.shutil, "which", lambda _name: str(fake_codex))
+
+    def _raise_timeout(*_args, **_kwargs):
+        raise installer_mod.subprocess.TimeoutExpired(cmd="codex --version", timeout=5)
+
+    monkeypatch.setattr(installer_mod.subprocess, "run", _raise_timeout)
+
+    result = installer_mod._check_codex_cli()
+    assert result.found is True
+    assert result.version is None
+    assert result.raw_output is None
+
+
+def test_install_npx_flow_with_assume_yes_warns_on_missing_codex(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+):
+    """The npx flow passes --assume-yes; warning must still surface."""
+    settings_path, claude_json_path, state_path, bin_dir = _fresh_paths(tmp_path)
+    codex_binary = _make_executable(bin_dir / "claude-anyteam")
+    _make_executable(bin_dir / "claude-anyteam-spawn-shim")
+
+    _stub_prereq_found(monkeypatch)
+    monkeypatch.setattr(installer_mod.shutil, "which", lambda name: None)
+    monkeypatch.setattr(
+        installer_mod,
+        "_check_codex_cli",
+        lambda: installer_mod.CodexCliCheck(
+            found=False, path=None, version=None, raw_output=None
+        ),
+    )
+    monkeypatch.setattr(cli_mod.sys, "argv", [str(codex_binary)])
+
+    # Simulate an existing claude.json so the --assume-yes branch of the
+    # prompt exercises too.
+    claude_json_path.parent.mkdir(parents=True, exist_ok=True)
+    claude_json_path.write_text(
+        json.dumps({installer_mod.TEAMMATE_MODE_KEY: "auto"}) + "\n",
+        encoding="utf-8",
+    )
+
+    exit_code = cli_mod.main(
+        _install_argv(settings_path, claude_json_path, state_path, "--assume-yes")
+    )
+    assert exit_code == 0
+
+    stdout = capsys.readouterr().out
+    assert "Warning: the OpenAI Codex CLI" in stdout


### PR DESCRIPTION
## Summary

- Adds a non-blocking `codex` CLI prereq check to the installer. Missing or below-floor (< 0.120) emits a warning with install/upgrade instructions, a `codex` sign-in hint, and a link to the setup guide; install still succeeds because codex-* teammates only need the binary at runtime.
- Reorders `install()` so both the tmux prereq and the codex probe run before any halt, meaning a user missing both sees them in a single pass under an `Additionally:` header rather than learning about each prereq serially across two runs.
- Introduces a regex-gated semver parser (`^\d+\.\d+(?:\.\d+)?(?:[-+][A-Za-z0-9.\-]+)?$`) so the floor check can't be fooled by noisy `codex --version` stdout. Parse failure falls back to a plain "Detected Codex CLI at …" line instead of a fabricated warning.

## Why

Users hitting `npx --yes claude-anyteam` without `codex` on PATH installed fine today, then got a confusing teammate-launch failure at runtime — no upfront signal that they still needed to install `codex`. Version drift below 0.120 caused the same class of runtime breakage, with even less context.

## Test plan

- [x] `uv run pytest` → 254 passed, 1 warning (pre-existing, unrelated)
- [x] 8 new tests covering: missing codex, below-floor, at-floor acceptance, version-parse failure, noisy-stdout parser picks the right token, direct `_check_codex_cli()` subprocess parse-fail branch, combined tmux+codex halt with `Additionally:` header, npx `--assume-yes` path surfaces the warning
- [ ] Smoke: run `uv tool install . && claude-anyteam install` on a box without `codex` on PATH and confirm the warning appears but install succeeds
- [ ] Smoke: run on a box with `codex` below 0.120 and confirm the below-floor warning names the detected version
- [ ] Smoke: run on a box missing both `tmux` and `codex` and confirm the `Additionally:` block is present in the halt message

## Review

Reviewed by a multi-agent team:
- **Implementer** (Claude Opus 4.7): wrote the feature, tests, and doc refreshes
- **Reviewer** (Codex gpt-5.5 / xhigh effort): code review, approved after a docstring nit
- **QC** (Codex gpt-5.5 / xhigh effort): user-UX verification, approved after confirming the two initial blockers (floor enforcement, prereq ordering) were fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)