### PR TITLE
team-cli: typed contract for team config (team-agent/team-patch/team-roster)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,17 @@ alice            → native Claude (unchanged)
 
 Codex- and Gemini-prefixed names appear in your TUI presence line exactly like native teammates. Single-terminal mode or tmux — both work.
 
+For per-teammate model/effort, use the `claude-anyteam team-agent` CLI (typed contract, atomic, allowlisted — preferred over hand-edits to `~/.claude/teams/`):
+
+```bash
+claude-anyteam team-agent codex-alice    --team build --model gpt-5.5 --effort xhigh
+claude-anyteam team-agent gemini-bob     --team build --model gemini-3-pro-preview --effort high
+claude-anyteam team-patch --team build --all-external   # set agentType=claude-anyteam on every codex-/gemini- member
+claude-anyteam team-roster --team build                  # one-line-per-member summary
+```
+
+See `docs/configuration.md#team-management-cli` for full reference.
+
 ## Why it feels native
 
 <table>

--- a/README.md
+++ b/README.md
@@ -54,17 +54,6 @@ alice            → native Claude (unchanged)
 
 Codex- and Gemini-prefixed names appear in your TUI presence line exactly like native teammates. Single-terminal mode or tmux — both work.
 
-For per-teammate model/effort, use the `claude-anyteam team-agent` CLI (typed contract, atomic, allowlisted — preferred over hand-edits to `~/.claude/teams/`):
-
-```bash
-claude-anyteam team-agent codex-alice    --team build --model gpt-5.5 --effort xhigh
-claude-anyteam team-agent gemini-bob     --team build --model gemini-3-pro-preview --effort high
-claude-anyteam team-patch --team build --all-external   # set agentType=claude-anyteam on every codex-/gemini- member
-claude-anyteam team-roster --team build                  # one-line-per-member summary
-```
-
-See `docs/configuration.md#team-management-cli` for full reference.
-
 ## Why it feels native
 
 <table>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -78,7 +78,15 @@ Claude Code's Agent Teams UI only passes name, team, and plan-mode to the spawn 
 ~/.claude/teams/<team>/agents/<agent-name>.json
 ```
 
-Example:
+**Use the `claude-anyteam team-agent` CLI to write this file.** It is the typed, allowlisted contract for managing per-teammate config — preferred over hand-written JSON or `Write` tool calls:
+
+```bash
+claude-anyteam team-agent codex-alice --team build --model gpt-5.5 --effort xhigh
+claude-anyteam team-agent gemini-bob  --team build --model gemini-3-pro-preview --effort high
+claude-anyteam team-agent codex-alice --team build --remove                       # delete the file
+```
+
+The CLI writes atomically, validates the agent/team names against path-traversal, drops unknown keys (only `model` / `effort` are honored), and is idempotent — re-running with the same args is a no-op. The on-disk shape is JSON that the shim reads at spawn time:
 
 ```json
 {
@@ -97,6 +105,18 @@ Behavior:
 - Native (`claude-*`) teammates — the file is not consulted; native dispatch is always pass-through.
 
 Precedence (highest wins): per-agent config file → env vars (`CLAUDE_ANYTEAM_MODEL`, `CLAUDE_ANYTEAM_EFFORT` for Codex, `CLAUDE_ANYTEAM_GEMINI_EFFORT` / `CLAUDE_ANYTEAM_GEMINI_TRUST` for Gemini) → adapter defaults → backend CLI defaults.
+
+## Team management CLI
+
+Three subcommands of `claude-anyteam` cover the routine team-management writes that previously required `Write`/`Edit`/`Bash` calls. They are all allowlisted by the installer (`Bash(claude-anyteam team-* *)`) so coordinating leads never hit a permission prompt.
+
+| Command | Purpose |
+|---|---|
+| `claude-anyteam team-agent <name> --team <team> [--model X] [--effort Y]` | Write `~/.claude/teams/<team>/agents/<name>.json`. Whitelisted keys: `model`, `effort`. Use `--remove` to delete. `--print-path` emits the file path on stdout. |
+| `claude-anyteam team-patch <name> --team <team>` <br> `claude-anyteam team-patch --team <team> --all-external` | Set `agentType="claude-anyteam"` on a routed-adapter member in `~/.claude/teams/<team>/config.json`. The host `Agent(...)` tool spawns external-LLM teammates with `agentType="general-purpose"` which the wrapper MCP rejects; this command is the post-spawn fixup. `--all-external` patches every `codex-*`, `gemini-*`, or `kimi-*` member at once. |
+| `claude-anyteam team-roster --team <team>` <br> `claude-anyteam team-roster --team <team> --json` | Print a one-line-per-member roster summary (or a JSON array) so a coordinating LLM can introspect the team without parsing config.json. |
+
+All three commands fail with exit 1 (or 2 for argparse errors) on missing teams, missing members, or malformed input — never silently. They are safe to run from automation and idempotent on no-op runs.
 
 ## Shim configuration
 

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -2,7 +2,7 @@
 set -eu
 
 SETTINGS_PATH=${HOME}/.claude/settings.json
-ORIENTATION_MESSAGE="claude-anyteam is installed; Agent Teams teammates named codex-* route to Codex and gemini-* route to Gemini CLI. Docs: https://github.com/JonathanRosado/claude-anyteam"
+ORIENTATION_MESSAGE="claude-anyteam is installed; Agent Teams teammates named codex-* route to Codex and gemini-* route to Gemini CLI. Use \`claude-anyteam team-agent|team-patch|team-roster\` for team config (preferred over hand-edits). Docs: https://github.com/JonathanRosado/claude-anyteam"
 DRIFT_WARNING='claude-anyteam: settings drifted — run `claude-anyteam install` to repair'
 
 settings_has_required_env() {

--- a/skills/help/SKILL.md
+++ b/skills/help/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: help
-description: Use proactively when the user wants help creating or managing Agent Teams teammates with claude-anyteam CLI backends.
-when_to_use: User asks to create, route, or troubleshoot codex-* or gemini-* Agent Teams teammates.
+description: Use proactively when the user wants help creating or managing Agent Teams teammates with claude-anyteam CLI backends. Includes the typed `claude-anyteam team-agent`, `team-patch`, and `team-roster` subcommands — prefer these over ad-hoc Write/Edit/Bash against `~/.claude/teams/`.
+when_to_use: User asks to create, route, configure, or troubleshoot codex-* or gemini-* Agent Teams teammates, OR the lead is about to write per-teammate model/effort config files or patch agentType after spawn.
 ---
 
 claude-anyteam lets Claude Code route selected Agent Teams teammates to external CLI agents through the installed spawn shim.
@@ -26,15 +26,20 @@ claude-anyteam lets Claude Code route selected Agent Teams teammates to external
 
 ## Setting model and effort per teammate
 
-The spawn shim reads `~/.claude/teams/<team>/agents/<name>.json` for per-teammate `model` and `effort` overrides and passes them as `--model X --effort Y` to the adapter. Missing file = adapter defaults. Write this file BEFORE calling `Agent(...)` for that teammate.
+**Use the `claude-anyteam team-agent` CLI, not raw file writes.** The spawn shim reads `~/.claude/teams/<team>/agents/<name>.json` for per-teammate `model` and `effort` overrides and passes them as `--model X --effort Y` to the adapter; the CLI is the typed contract for writing those files. Run it BEFORE calling `Agent(...)` for that teammate. Missing file = adapter defaults.
+
+```bash
+claude-anyteam team-agent codex-implementer --team build-team --model gpt-5.5 --effort xhigh
+claude-anyteam team-agent gemini-reviewer   --team build-team --model gemini-3-pro-preview --effort xhigh
+```
 
 When the user asks for "best models and effort" or otherwise specifies model/effort intent:
 
-- For each `codex-*` member, write `{"model": "gpt-5.5", "effort": "xhigh"}`.
-- For each `gemini-*` member, write `{"model": "gemini-3-pro-preview", "effort": "xhigh"}`. The Gemini CLI's `Auto (Gemini 3)` UI label shows `gemini-3.1-pro` but that string is **not** a direct-API model — it only works via the CLI's auto-router. Pass `gemini-3-pro-preview` for explicit `--model` selection, or fall back to `gemini-2.5-pro` if Gemini 3 quota is exhausted.
+- For each `codex-*` member: `claude-anyteam team-agent <name> --team <team> --model gpt-5.5 --effort xhigh`.
+- For each `gemini-*` member: `claude-anyteam team-agent <name> --team <team> --model gemini-3-pro-preview --effort xhigh`. The Gemini CLI's `Auto (Gemini 3)` UI label shows `gemini-3.1-pro` but that string is **not** a direct-API model — it only works via the CLI's auto-router. Pass `gemini-3-pro-preview` for explicit `--model` selection, or fall back to `gemini-2.5-pro` if Gemini 3 quota is exhausted.
 - For each native Claude member, pass `model="opus"` directly to the `Agent(...)` call. Native Claude teammates use the host's Agent-tool model param, not the agent config file.
 
-The user does not interact with the JSON files; the lead writes them as part of the spawn flow.
+The user does not interact with the CLI directly; the lead invokes it as part of the spawn flow. To remove a config: `claude-anyteam team-agent <name> --team <team> --remove`.
 
 ## Briefing teammates for orchestration and memory
 
@@ -46,9 +51,25 @@ External-CLI teammates (`codex-*`, `gemini-*`) don't share the lead's context. E
 4. **Task discipline.** Teammates should use `TaskList`/`TaskUpdate` to claim and progress tasks. Tell them: "Mark `in_progress` only when actually working, `completed` only when verifiably done. Don't move tasks while waiting for triggers."
 5. **Park instructions.** When a teammate must wait (e.g., a tester waiting for an implementer's PR), tell them explicitly: "Do nothing — no file reads, no fixture setup, no progress reports. Idle until I message you with a go-signal."
 
-## Patching agentType after spawn (current workaround)
+## Patching agentType after spawn
 
-The host `Agent(...)` tool spawn omits `agentType` from new member entries in `~/.claude/teams/<team>/config.json`. The teammate's MCP probe rejects the config on startup, breaking inter-teammate `SendMessage`. Until this is fixed, the lead must edit each new member entry to add `"agentType": "<role>"` (e.g. `"researcher"`, `"implementer"`, `"reviewer"`) right after the `Agent(...)` calls. A single Python pass over the config covers all members at once. Do this before expecting any teammate to message.
+The host `Agent(...)` tool spawn omits `agentType` from new member entries in `~/.claude/teams/<team>/config.json` (it writes `agentType="general-purpose"`). The teammate's MCP probe expects `agentType="claude-anyteam"` for routed-adapter members; without the patch, inter-teammate `SendMessage` breaks. Use the CLI:
+
+```bash
+claude-anyteam team-patch --team build-team --all-external      # patches every codex-/gemini-/kimi- member
+claude-anyteam team-patch codex-alice --team build-team          # or one at a time
+```
+
+Run this once after all `Agent(...)` calls land. The CLI is idempotent — re-running on already-patched members is a no-op.
+
+## Inspecting team state
+
+To see the current roster without reading and parsing config.json by hand:
+
+```bash
+claude-anyteam team-roster --team build-team           # human-readable
+claude-anyteam team-roster --team build-team --json    # JSON array for scripted callers
+```
 
 ## Example
 
@@ -58,8 +79,8 @@ Mixed-backend team where every member runs at top effort:
 TeamCreate(team_name="build-team")
 
 # 1. Write per-teammate agent configs BEFORE Agent(...) calls.
-write ~/.claude/teams/build-team/agents/codex-implementer.json   {"model": "gpt-5.5", "effort": "xhigh"}
-write ~/.claude/teams/build-team/agents/gemini-reviewer.json     {"model": "gemini-3-pro-preview", "effort": "xhigh"}
+claude-anyteam team-agent codex-implementer --team build-team --model gpt-5.5 --effort xhigh
+claude-anyteam team-agent gemini-reviewer   --team build-team --model gemini-3-pro-preview --effort xhigh
 
 # 2. Spawn. Native Claude teammates take model via Agent's own param.
 Agent(team_name="build-team", name="codex-implementer", prompt="Implement the patch.")
@@ -67,8 +88,15 @@ Agent(team_name="build-team", name="gemini-reviewer", prompt="Review from a Gemi
 Agent(team_name="build-team", name="claude-planner", model="opus", prompt="Plan the approach.")
 Agent(team_name="build-team", name="reviewer", model="opus", prompt="Review the final result.")
 
-# 3. Patch agentType on every new member entry in
-#    ~/.claude/teams/build-team/config.json before expecting messaging to work.
+# 3. Patch agentType on every new routed-adapter member in one call.
+claude-anyteam team-patch --team build-team --all-external
+
+# 4. (Optional) Confirm the roster looks right.
+claude-anyteam team-roster --team build-team
 ```
 
 If the user asks why a teammate did not route through claude-anyteam, check the prefix first: `codex-` and `gemini-` are the default routing regexes.
+
+## Why the CLI exists
+
+Earlier versions of this skill instructed leads to write the JSON config files and patch `config.json` by hand. That worked but left a wide blast radius — the lead had to know the magic file paths, JSON shape, and which post-spawn fixups to apply. The `claude-anyteam team-*` subcommands are a typed contract: they validate inputs, write atomically, are idempotent, and — most importantly — are allowlisted in the installer (`Bash(claude-anyteam team-* *)`) so they never trigger permission prompts. **Future sessions: prefer the CLI over `Write`/`Edit`/`Bash` against `~/.claude/teams/`.**

--- a/src/claude_anyteam/cli.py
+++ b/src/claude_anyteam/cli.py
@@ -31,8 +31,11 @@ def _build_run_parser() -> argparse.ArgumentParser:
         description="Route Codex- and Gemini-backed teammates into Claude Code with the claude-anyteam adapter.",
         epilog=(
             "Management commands:\n"
-            "  claude-anyteam install    Persist the claude-anyteam shim in ~/.claude/settings.json\n"
-            "  claude-anyteam uninstall  Remove the installed Codex/Gemini teammate shim settings"
+            "  claude-anyteam install      Persist the claude-anyteam shim in ~/.claude/settings.json\n"
+            "  claude-anyteam uninstall    Remove the installed Codex/Gemini teammate shim settings\n"
+            "  claude-anyteam team-agent   Write per-teammate model/effort to ~/.claude/teams/<team>/agents/<agent>.json\n"
+            "  claude-anyteam team-patch   Patch agentType post-spawn so wrapper MCP validation passes\n"
+            "  claude-anyteam team-roster  Print one-line-per-member team summary"
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -301,6 +304,9 @@ def main(argv: list[str] | None = None) -> int:
             if args.state_path is not None:
                 kwargs["state_path"] = args.state_path
             return _uninstall_command(**kwargs)
+        if command in ("team-agent", "team-patch", "team-roster"):
+            from . import team_cli
+            return team_cli.main_dispatch(command, argv[1:])
 
     args = _parse_args(argv)
 

--- a/src/claude_anyteam/installer.py
+++ b/src/claude_anyteam/installer.py
@@ -43,6 +43,9 @@ RECOMMENDED_ALLOWLIST_ENTRIES = (
     "Bash(pkill -f gemini-anyteam *)",
     "Bash(pkill -f claude-anyteam *)",
     "Bash(mkdir -p ~/.claude/teams/**)",
+    "Bash(claude-anyteam team-agent *)",
+    "Bash(claude-anyteam team-patch *)",
+    "Bash(claude-anyteam team-roster *)",
 )
 
 MANAGED_BINARY_KEYS = (TEAMMATE_BINARY_KEY, GEMINI_TEAMMATE_BINARY_KEY, LEGACY_TEAMMATE_BINARY_KEY)

--- a/src/claude_anyteam/team_cli.py
+++ b/src/claude_anyteam/team_cli.py
@@ -1,0 +1,415 @@
+"""Team-management CLI helpers.
+
+Three subcommands of ``claude-anyteam``:
+
+  * ``team-agent``  — write per-teammate ``model``/``effort`` overrides at
+                      ``~/.claude/teams/<team>/agents/<agent>.json``. The spawn
+                      shim reads this file and forwards the values to the
+                      routed adapter (Codex, Gemini, Kimi).
+
+  * ``team-patch``  — apply post-spawn fixups to a teammate row in
+                      ``~/.claude/teams/<team>/config.json``. Today this
+                      means setting ``agentType`` to ``claude-anyteam`` so
+                      the wrapper MCP validation passes; the Agent tool
+                      omits this field when spawning external-LLM teammates.
+
+  * ``team-roster`` — print a one-line-per-member roster summary so a
+                      coordinating LLM can introspect the team without
+                      reading and parsing config.json by hand.
+
+These commands exist so a coordinating LLM has a typed, allowlistable
+contract for team management and does not have to know magic file paths,
+JSON shapes, or which fields need which post-spawn fixups. Future
+sessions: prefer ``claude-anyteam team-*`` over ad-hoc Write/Edit/Bash.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TextIO
+
+# Effort whitelist mirrors the per-backend allowlists (Codex/Gemini/Kimi all
+# accept the same five-tier scale). If a future backend diverges, this
+# becomes the union and the per-backend adapter remains the source of truth.
+EFFORT_CHOICES = ("minimal", "low", "medium", "high", "xhigh")
+
+# Whitelisted keys mirror spawn_shim._AGENT_CONFIG_KEYS; expanding this set
+# requires extending the shim too.
+AGENT_CONFIG_KEYS = ("model", "effort")
+
+# Default post-spawn agentType for codex-/gemini-/kimi- teammates. The Agent
+# tool spawns them with ``agentType="general-purpose"``, which fails wrapper
+# MCP validation; ``claude-anyteam`` is the canonical value.
+DEFAULT_PATCHED_AGENT_TYPE = "claude-anyteam"
+
+
+def _teams_root() -> Path:
+    return Path.home() / ".claude" / "teams"
+
+
+def agent_config_path(team: str, agent: str) -> Path:
+    return _teams_root() / team / "agents" / f"{agent}.json"
+
+
+def team_config_path(team: str) -> Path:
+    return _teams_root() / team / "config.json"
+
+
+def _validate_team_name(value: str) -> str:
+    if not value or any(ch in value for ch in ("/", "\\", "\x00")):
+        raise argparse.ArgumentTypeError(
+            f"invalid team name {value!r}: must be non-empty and contain no path separators"
+        )
+    if value in (".", ".."):
+        raise argparse.ArgumentTypeError(f"invalid team name {value!r}")
+    return value
+
+
+def _validate_agent_name(value: str) -> str:
+    if not value or any(ch in value for ch in ("/", "\\", "\x00")):
+        raise argparse.ArgumentTypeError(
+            f"invalid agent name {value!r}: must be non-empty and contain no path separators"
+        )
+    if value in (".", ".."):
+        raise argparse.ArgumentTypeError(f"invalid agent name {value!r}")
+    return value
+
+
+def _write_atomic_json(path: Path, data: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def _existing_dict(path: Path) -> dict[str, object]:
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {}
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return raw if isinstance(raw, dict) else {}
+
+
+# --------------------------------------------------------------------------- #
+# team-agent
+# --------------------------------------------------------------------------- #
+
+
+def _build_team_agent_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="claude-anyteam team-agent",
+        description=(
+            "Write or update a per-teammate config file at "
+            "~/.claude/teams/<team>/agents/<agent>.json. The spawn shim reads "
+            "this file and forwards --model/--effort to the routed adapter."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Examples:\n"
+            "  claude-anyteam team-agent codex-alice --team build --model gpt-5.5 --effort xhigh\n"
+            "  claude-anyteam team-agent gemini-bob  --team build --model gemini-3.1-pro-preview --effort high\n"
+            "  claude-anyteam team-agent kimi-cara   --team build --model kimi-for-coding\n"
+            "  claude-anyteam team-agent codex-alice --team build --remove\n"
+            "\nThe agent name's prefix (codex-/gemini-/kimi-) determines which adapter receives the\n"
+            "config; this command does not validate the model slug against any backend catalog."
+        ),
+    )
+    p.add_argument("agent", type=_validate_agent_name, help="Agent name (e.g. codex-alice, gemini-bob, kimi-cara)")
+    p.add_argument("--team", type=_validate_team_name, required=True, help="Team name (the parent directory under ~/.claude/teams/)")
+    p.add_argument("--model", help="Model slug to forward as --model to the adapter")
+    p.add_argument(
+        "--effort",
+        choices=EFFORT_CHOICES,
+        help="Reasoning/thinking effort to forward as --effort to the adapter",
+    )
+    p.add_argument(
+        "--remove",
+        action="store_true",
+        help="Delete the per-teammate config file instead of writing one",
+    )
+    p.add_argument(
+        "--print-path",
+        action="store_true",
+        help="After writing, print the absolute config path on stdout (default: print a one-line summary)",
+    )
+    return p
+
+
+def _team_agent_command(argv: list[str], *, stdout: TextIO | None = None, stderr: TextIO | None = None) -> int:
+    out = stdout if stdout is not None else sys.stdout
+    err = stderr if stderr is not None else sys.stderr
+    parser = _build_team_agent_parser()
+    args = parser.parse_args(argv)
+
+    path = agent_config_path(args.team, args.agent)
+
+    if args.remove:
+        try:
+            path.unlink()
+            out.write(f"removed {path}\n")
+            return 0
+        except FileNotFoundError:
+            out.write(f"no config to remove at {path}\n")
+            return 0
+        except OSError as exc:
+            err.write(f"failed to remove {path}: {exc}\n")
+            return 1
+
+    if args.model is None and args.effort is None:
+        err.write(
+            "error: at least one of --model/--effort must be provided (or use --remove to delete)\n"
+        )
+        return 2
+
+    config = _existing_dict(path)
+    config = {k: v for k, v in config.items() if k in AGENT_CONFIG_KEYS}
+
+    if args.model is not None:
+        config["model"] = args.model
+    if args.effort is not None:
+        config["effort"] = args.effort
+
+    _write_atomic_json(path, config)
+
+    if args.print_path:
+        out.write(f"{path}\n")
+    else:
+        keys = ", ".join(f"{k}={v}" for k, v in sorted(config.items()))
+        out.write(f"wrote {path} ({keys})\n")
+    return 0
+
+
+# --------------------------------------------------------------------------- #
+# team-patch
+# --------------------------------------------------------------------------- #
+
+
+def _build_team_patch_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="claude-anyteam team-patch",
+        description=(
+            "Apply post-spawn fixups to a teammate row in "
+            "~/.claude/teams/<team>/config.json. The Agent tool spawns "
+            "external-LLM teammates with agentType='general-purpose'; the "
+            "wrapper MCP requires agentType='claude-anyteam'. This command "
+            "patches that field idempotently."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Examples:\n"
+            "  claude-anyteam team-patch codex-alice --team build\n"
+            "  claude-anyteam team-patch --team build --all-external\n"
+            "\nWith --all-external the command patches every member whose name starts with\n"
+            "codex-, gemini-, or kimi- (the routed-adapter prefixes)."
+        ),
+    )
+    p.add_argument(
+        "agent",
+        nargs="?",
+        type=_validate_agent_name,
+        help="Agent name to patch (omit when using --all-external)",
+    )
+    p.add_argument("--team", type=_validate_team_name, required=True, help="Team name")
+    p.add_argument(
+        "--agent-type",
+        default=DEFAULT_PATCHED_AGENT_TYPE,
+        help=f"agentType value to write (default: {DEFAULT_PATCHED_AGENT_TYPE})",
+    )
+    p.add_argument(
+        "--all-external",
+        action="store_true",
+        help="Patch every member with a routed-adapter prefix (codex-/gemini-/kimi-)",
+    )
+    return p
+
+
+_ROUTED_PREFIXES = ("codex-", "gemini-", "kimi-")
+
+
+def _team_patch_command(argv: list[str], *, stdout: TextIO | None = None, stderr: TextIO | None = None) -> int:
+    out = stdout if stdout is not None else sys.stdout
+    err = stderr if stderr is not None else sys.stderr
+    parser = _build_team_patch_parser()
+    args = parser.parse_args(argv)
+
+    if args.all_external == bool(args.agent):
+        err.write("error: provide exactly one of <agent> or --all-external\n")
+        return 2
+
+    path = team_config_path(args.team)
+    if not path.exists():
+        err.write(f"error: no team config at {path}\n")
+        return 1
+
+    cfg = _existing_dict(path)
+    members = cfg.get("members")
+    if not isinstance(members, list):
+        err.write(f"error: {path} has no 'members' list\n")
+        return 1
+
+    targets: list[str]
+    if args.all_external:
+        targets = [
+            m["name"]
+            for m in members
+            if isinstance(m, dict)
+            and isinstance(m.get("name"), str)
+            and m["name"].startswith(_ROUTED_PREFIXES)
+        ]
+        if not targets:
+            out.write(f"no routed-adapter members in {path}\n")
+            return 0
+    else:
+        targets = [args.agent]
+
+    patched: list[str] = []
+    missing: list[str] = []
+    for name in targets:
+        member = next(
+            (m for m in members if isinstance(m, dict) and m.get("name") == name),
+            None,
+        )
+        if member is None:
+            missing.append(name)
+            continue
+        if member.get("agentType") == args.agent_type:
+            continue
+        member["agentType"] = args.agent_type
+        patched.append(name)
+
+    if patched:
+        _write_atomic_json(path, cfg)
+
+    if missing:
+        err.write(f"warning: members not found: {', '.join(missing)}\n")
+    if patched:
+        out.write(f"patched agentType={args.agent_type} on {len(patched)} member(s): {', '.join(patched)}\n")
+    elif not missing:
+        out.write("no changes needed\n")
+    return 1 if missing and not patched else 0
+
+
+# --------------------------------------------------------------------------- #
+# team-roster
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class _RosterRow:
+    name: str
+    agent_type: str
+    model: str
+    backend_type: str
+    color: str
+
+
+def _build_team_roster_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="claude-anyteam team-roster",
+        description=(
+            "Print a one-line-per-member summary of the team's config.json. "
+            "Use this instead of reading and parsing the file by hand."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("--team", type=_validate_team_name, required=True, help="Team name")
+    p.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit a JSON array instead of the human-readable table",
+    )
+    return p
+
+
+def _roster_rows(cfg: dict[str, object]) -> list[_RosterRow]:
+    members = cfg.get("members")
+    if not isinstance(members, list):
+        return []
+    rows: list[_RosterRow] = []
+    for m in members:
+        if not isinstance(m, dict):
+            continue
+        rows.append(
+            _RosterRow(
+                name=str(m.get("name", "?")),
+                agent_type=str(m.get("agentType", "?")),
+                model=str(m.get("model", "?")),
+                backend_type=str(m.get("backendType", "?")),
+                color=str(m.get("color", "?")),
+            )
+        )
+    return rows
+
+
+def _team_roster_command(argv: list[str], *, stdout: TextIO | None = None, stderr: TextIO | None = None) -> int:
+    out = stdout if stdout is not None else sys.stdout
+    err = stderr if stderr is not None else sys.stderr
+    parser = _build_team_roster_parser()
+    args = parser.parse_args(argv)
+
+    path = team_config_path(args.team)
+    if not path.exists():
+        err.write(f"error: no team config at {path}\n")
+        return 1
+
+    cfg = _existing_dict(path)
+    rows = _roster_rows(cfg)
+
+    if args.json:
+        out.write(json.dumps([row.__dict__ for row in rows], indent=2, sort_keys=True) + "\n")
+        return 0
+
+    if not rows:
+        out.write(f"team {args.team!r} has no members\n")
+        return 0
+
+    name_w = max(len(r.name) for r in rows)
+    type_w = max(len(r.agent_type) for r in rows)
+    model_w = max(len(r.model) for r in rows)
+    for r in rows:
+        out.write(
+            f"  {r.name:<{name_w}}  type={r.agent_type:<{type_w}}  model={r.model:<{model_w}}  "
+            f"backend={r.backend_type}  color={r.color}\n"
+        )
+    return 0
+
+
+# --------------------------------------------------------------------------- #
+# Dispatch
+# --------------------------------------------------------------------------- #
+
+
+_SUBCOMMANDS = {
+    "team-agent": _team_agent_command,
+    "team-patch": _team_patch_command,
+    "team-roster": _team_roster_command,
+}
+
+
+def main_dispatch(subcommand: str, argv: list[str]) -> int:
+    """Dispatch a ``team-*`` subcommand by name.
+
+    Called from ``claude_anyteam.cli.main`` when the first positional arg
+    matches one of the team-* subcommands.
+    """
+    handler = _SUBCOMMANDS.get(subcommand)
+    if handler is None:
+        sys.stderr.write(f"error: unknown subcommand {subcommand!r}\n")
+        return 2
+    return handler(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Standalone entry point used by ``team-agent``-only invocations."""
+    return _team_agent_command(list(argv) if argv is not None else sys.argv[1:])
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_plugin_bundle.py
+++ b/tests/test_plugin_bundle.py
@@ -16,7 +16,8 @@ HELP_SKILL = REPO_ROOT / "skills" / "help" / "SKILL.md"
 STATUS_SKILL = REPO_ROOT / "skills" / "status" / "SKILL.md"
 ORIENTATION_MESSAGE = (
     "claude-anyteam is installed; Agent Teams teammates named codex-* route to Codex "
-    "and gemini-* route to Gemini CLI. Docs: https://github.com/JonathanRosado/claude-anyteam"
+    "and gemini-* route to Gemini CLI. Use `claude-anyteam team-agent|team-patch|team-roster` "
+    "for team config (preferred over hand-edits). Docs: https://github.com/JonathanRosado/claude-anyteam"
 )
 DRIFT_WARNING = "claude-anyteam: settings drifted — run `claude-anyteam install` to repair"
 

--- a/tests/test_team_cli.py
+++ b/tests/test_team_cli.py
@@ -1,0 +1,262 @@
+"""Coverage for the ``claude-anyteam team-*`` subcommands.
+
+Each test patches HOME via monkeypatch so writes land in tmp_path; no real
+~/.claude state is touched.
+"""
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+from claude_anyteam import team_cli
+from claude_anyteam.cli import main as cli_main
+
+
+@pytest.fixture
+def fake_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    return tmp_path
+
+
+def _agent_path(home: Path, team: str, agent: str) -> Path:
+    return home / ".claude" / "teams" / team / "agents" / f"{agent}.json"
+
+
+def _team_path(home: Path, team: str) -> Path:
+    return home / ".claude" / "teams" / team / "config.json"
+
+
+# --------------------------------------------------------------------------- #
+# team-agent
+# --------------------------------------------------------------------------- #
+
+
+def test_team_agent_writes_model_and_effort(fake_home, capsys):
+    rc = cli_main(["team-agent", "codex-alice", "--team", "build", "--model", "gpt-5.5", "--effort", "xhigh"])
+    assert rc == 0
+    cfg = json.loads(_agent_path(fake_home, "build", "codex-alice").read_text())
+    assert cfg == {"model": "gpt-5.5", "effort": "xhigh"}
+    out = capsys.readouterr().out
+    assert "wrote " in out
+    assert "model=gpt-5.5" in out
+    assert "effort=xhigh" in out
+
+
+def test_team_agent_model_only_omits_effort(fake_home):
+    rc = cli_main(["team-agent", "kimi-cara", "--team", "build", "--model", "kimi-for-coding"])
+    assert rc == 0
+    cfg = json.loads(_agent_path(fake_home, "build", "kimi-cara").read_text())
+    assert cfg == {"model": "kimi-for-coding"}
+
+
+def test_team_agent_effort_only_omits_model(fake_home):
+    rc = cli_main(["team-agent", "gemini-bob", "--team", "build", "--effort", "high"])
+    assert rc == 0
+    cfg = json.loads(_agent_path(fake_home, "build", "gemini-bob").read_text())
+    assert cfg == {"effort": "high"}
+
+
+def test_team_agent_neither_model_nor_effort_is_an_error(fake_home, capsys):
+    rc = cli_main(["team-agent", "codex-alice", "--team", "build"])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "at least one of --model/--effort" in err
+
+
+def test_team_agent_overwrites_existing_keys(fake_home):
+    cli_main(["team-agent", "codex-alice", "--team", "build", "--model", "gpt-5.4", "--effort", "low"])
+    cli_main(["team-agent", "codex-alice", "--team", "build", "--model", "gpt-5.5"])
+    cfg = json.loads(_agent_path(fake_home, "build", "codex-alice").read_text())
+    # Effort persists from the first call; model is updated by the second
+    assert cfg == {"model": "gpt-5.5", "effort": "low"}
+
+
+def test_team_agent_strips_unknown_keys_on_write(fake_home):
+    path = _agent_path(fake_home, "build", "codex-alice")
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps({"model": "gpt-5.5", "effort": "high", "rogue_key": "bad"}))
+    cli_main(["team-agent", "codex-alice", "--team", "build", "--effort", "xhigh"])
+    cfg = json.loads(path.read_text())
+    assert cfg == {"model": "gpt-5.5", "effort": "xhigh"}
+    assert "rogue_key" not in cfg
+
+
+def test_team_agent_remove_deletes_existing(fake_home, capsys):
+    cli_main(["team-agent", "codex-alice", "--team", "build", "--model", "gpt-5.5"])
+    rc = cli_main(["team-agent", "codex-alice", "--team", "build", "--remove"])
+    assert rc == 0
+    assert not _agent_path(fake_home, "build", "codex-alice").exists()
+    assert "removed " in capsys.readouterr().out
+
+
+def test_team_agent_remove_missing_is_idempotent(fake_home, capsys):
+    rc = cli_main(["team-agent", "codex-alice", "--team", "build", "--remove"])
+    assert rc == 0
+    assert "no config to remove" in capsys.readouterr().out
+
+
+def test_team_agent_rejects_path_traversal_in_team(fake_home, capsys):
+    with pytest.raises(SystemExit) as exc:
+        cli_main(["team-agent", "codex-alice", "--team", "../etc", "--model", "x"])
+    assert exc.value.code == 2
+
+
+def test_team_agent_rejects_path_traversal_in_agent(fake_home, capsys):
+    with pytest.raises(SystemExit) as exc:
+        cli_main(["team-agent", "codex/../alice", "--team", "build", "--model", "x"])
+    assert exc.value.code == 2
+
+
+def test_team_agent_print_path_emits_only_path(fake_home, capsys):
+    rc = cli_main(["team-agent", "codex-alice", "--team", "build", "--model", "gpt-5.5", "--print-path"])
+    assert rc == 0
+    out = capsys.readouterr().out.strip()
+    assert out == str(_agent_path(fake_home, "build", "codex-alice"))
+
+
+def test_team_agent_invalid_effort_is_rejected(fake_home, capsys):
+    with pytest.raises(SystemExit) as exc:
+        cli_main(["team-agent", "codex-alice", "--team", "build", "--effort", "absurd"])
+    assert exc.value.code == 2
+
+
+# --------------------------------------------------------------------------- #
+# team-patch
+# --------------------------------------------------------------------------- #
+
+
+def _seed_team_config(home: Path, team: str, members: list[dict]) -> None:
+    p = _team_path(home, team)
+    p.parent.mkdir(parents=True)
+    p.write_text(json.dumps({"name": team, "members": members}))
+
+
+def test_team_patch_sets_agent_type_for_named_agent(fake_home, capsys):
+    _seed_team_config(fake_home, "build", [
+        {"name": "codex-alice", "agentType": "general-purpose"},
+        {"name": "codex-bob", "agentType": "claude-anyteam"},
+    ])
+    rc = cli_main(["team-patch", "codex-alice", "--team", "build"])
+    assert rc == 0
+    cfg = json.loads(_team_path(fake_home, "build").read_text())
+    members = {m["name"]: m for m in cfg["members"]}
+    assert members["codex-alice"]["agentType"] == "claude-anyteam"
+    assert members["codex-bob"]["agentType"] == "claude-anyteam"
+    assert "patched agentType=claude-anyteam on 1 member" in capsys.readouterr().out
+
+
+def test_team_patch_all_external_patches_routed_prefixes(fake_home, capsys):
+    _seed_team_config(fake_home, "build", [
+        {"name": "team-lead", "agentType": "tech-lead"},
+        {"name": "codex-alice", "agentType": "general-purpose"},
+        {"name": "gemini-bob", "agentType": "general-purpose"},
+        {"name": "kimi-cara", "agentType": "general-purpose"},
+        {"name": "researcher", "agentType": "research"},
+    ])
+    rc = cli_main(["team-patch", "--team", "build", "--all-external"])
+    assert rc == 0
+    cfg = json.loads(_team_path(fake_home, "build").read_text())
+    members = {m["name"]: m for m in cfg["members"]}
+    assert members["codex-alice"]["agentType"] == "claude-anyteam"
+    assert members["gemini-bob"]["agentType"] == "claude-anyteam"
+    assert members["kimi-cara"]["agentType"] == "claude-anyteam"
+    # Non-routed members untouched
+    assert members["team-lead"]["agentType"] == "tech-lead"
+    assert members["researcher"]["agentType"] == "research"
+
+
+def test_team_patch_idempotent_no_changes(fake_home, capsys):
+    _seed_team_config(fake_home, "build", [
+        {"name": "codex-alice", "agentType": "claude-anyteam"},
+    ])
+    rc = cli_main(["team-patch", "codex-alice", "--team", "build"])
+    assert rc == 0
+    assert "no changes needed" in capsys.readouterr().out
+
+
+def test_team_patch_unknown_agent_warns_and_exits_nonzero(fake_home, capsys):
+    _seed_team_config(fake_home, "build", [
+        {"name": "codex-alice", "agentType": "general-purpose"},
+    ])
+    rc = cli_main(["team-patch", "codex-bob", "--team", "build"])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "members not found: codex-bob" in err
+
+
+def test_team_patch_requires_either_agent_or_all_external(fake_home, capsys):
+    _seed_team_config(fake_home, "build", [{"name": "codex-alice", "agentType": "general-purpose"}])
+    rc = cli_main(["team-patch", "--team", "build"])
+    assert rc == 2
+
+
+def test_team_patch_rejects_both_agent_and_all_external(fake_home, capsys):
+    _seed_team_config(fake_home, "build", [{"name": "codex-alice", "agentType": "general-purpose"}])
+    rc = cli_main(["team-patch", "codex-alice", "--team", "build", "--all-external"])
+    assert rc == 2
+
+
+def test_team_patch_missing_team_config(fake_home, capsys):
+    rc = cli_main(["team-patch", "codex-alice", "--team", "missing"])
+    assert rc == 1
+    assert "no team config" in capsys.readouterr().err
+
+
+# --------------------------------------------------------------------------- #
+# team-roster
+# --------------------------------------------------------------------------- #
+
+
+def test_team_roster_human_readable(fake_home, capsys):
+    _seed_team_config(fake_home, "build", [
+        {"name": "team-lead", "agentType": "tech-lead", "model": "claude-opus-4-7", "backendType": "tmux", "color": "blue"},
+        {"name": "codex-alice", "agentType": "claude-anyteam", "model": "codex-cli", "backendType": "in-process", "color": "green"},
+    ])
+    rc = cli_main(["team-roster", "--team", "build"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "team-lead" in out
+    assert "codex-alice" in out
+    assert "codex-cli" in out
+    assert "tech-lead" in out
+
+
+def test_team_roster_json_output(fake_home, capsys):
+    _seed_team_config(fake_home, "build", [
+        {"name": "codex-alice", "agentType": "claude-anyteam", "model": "codex-cli", "backendType": "in-process", "color": "green"},
+    ])
+    rc = cli_main(["team-roster", "--team", "build", "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload[0]["name"] == "codex-alice"
+    assert payload[0]["model"] == "codex-cli"
+
+
+def test_team_roster_empty_members(fake_home, capsys):
+    _seed_team_config(fake_home, "build", [])
+    rc = cli_main(["team-roster", "--team", "build"])
+    assert rc == 0
+    assert "has no members" in capsys.readouterr().out
+
+
+def test_team_roster_missing_team(fake_home, capsys):
+    rc = cli_main(["team-roster", "--team", "missing"])
+    assert rc == 1
+    assert "no team config" in capsys.readouterr().err
+
+
+# --------------------------------------------------------------------------- #
+# Atomic write semantics
+# --------------------------------------------------------------------------- #
+
+
+def test_team_agent_write_is_atomic(fake_home):
+    """The .tmp sibling must not survive a successful write."""
+    cli_main(["team-agent", "codex-alice", "--team", "build", "--model", "gpt-5.5"])
+    parent = _agent_path(fake_home, "build", "codex-alice").parent
+    leftovers = [p for p in parent.iterdir() if p.suffix == ".tmp"]
+    assert leftovers == []


### PR DESCRIPTION
## Summary

Adds three subcommands of `claude-anyteam` so coordinating leads can manage team state without ad-hoc `Write`/`Edit`/`Bash` calls against `~/.claude/teams/`:

- **`team-agent`** — write/update/delete per-teammate `model`/`effort` overrides at `~/.claude/teams/<team>/agents/<agent>.json`. The spawn shim already reads this file; this is the typed write path.
- **`team-patch`** — set `agentType="claude-anyteam"` on a routed-adapter member in `~/.claude/teams/<team>/config.json`. The host `Agent(...)` tool spawns external-LLM teammates with `agentType="general-purpose"` which the wrapper MCP rejects; this is the post-spawn fixup. `--all-external` patches every `codex-`/`gemini-`/`kimi-` member at once.
- **`team-roster`** — print a one-line-per-member roster summary (or JSON) so a coordinating LLM can introspect the team without parsing `config.json` by hand.

All three are allowlisted via the installer (`Bash(claude-anyteam team-* *)`), atomic, idempotent, validate inputs against path traversal, and exit with distinct codes for argparse errors (2), runtime errors (1), and success (0).

The help skill, `docs/configuration.md`, and the SessionStart hook orientation message are updated to teach future sessions to prefer the CLI over hand-edits. The skill description is broadened so it triggers when a lead is about to write team state, not just when the user asks for help.

## Why

Coordinating an Agent Teams swarm currently requires the lead to know the magic file paths under `~/.claude/teams/`, the JSON shape, and which post-spawn fixups to apply. Every spawn cycle hits permission prompts (`Bash(mkdir -p ...)`, `Write(~/.claude/teams/...)`) and a hand-written JSON file. This PR replaces that with a typed contract: the lead runs three commands, the rest is mechanical.

## Test plan

- [x] `pytest -m "not integration"` — 409 passed (24 new `test_team_cli.py` tests + 385 existing, no regressions)
- [x] `claude-anyteam team-agent codex-alice --team build --model gpt-5.5 --effort xhigh` — writes `~/.claude/teams/build/agents/codex-alice.json` with the expected shape
- [x] `claude-anyteam team-patch --team build --all-external` — patches `agentType` on every routed-adapter member
- [x] `claude-anyteam team-roster --team build` — prints the roster
- [x] Path traversal in team/agent name rejected with exit 2
- [x] Atomic write contract: no `.tmp` siblings survive a successful write
- [x] `--remove` is idempotent (exit 0 even if the file was already gone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)