### PR TITLE
installer: handholding UX, dep auto-install prompts, prefilled issue links, fastmcp pre-release fix

### DIFF
--- a/npm/bin/setup.js
+++ b/npm/bin/setup.js
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
 import { spawn } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { arch, release } from 'node:os';
 import readline from 'node:readline/promises';
 import process from 'node:process';
 import yoctoSpinner from 'yocto-spinner';
@@ -15,10 +17,12 @@ import {
   formatDisplayPath,
   formatCommand,
   installTool,
+  installPython,
   installUv,
   isCI,
   isInteractive,
   manualInstallLines,
+  nodeInstallLines,
   providerPrereqLines,
   runCommand,
   uvToolEnv,
@@ -26,7 +30,7 @@ import {
   which,
 } from '../lib/detect.js';
 import { renderBanner, renderBox, theme } from '../lib/art.js';
-import { isPythonVersionTooOld, translate } from '../lib/error-translator.js';
+import { formatInstallerDiagnostic, isPythonVersionTooOld, translate } from '../lib/error-translator.js';
 
 const CLAUDE_PLUGIN_MARKETPLACE_SOURCE = 'JonathanRosado/claude-anyteam';
 const CLAUDE_PLUGIN_MARKETPLACE_NAME = 'claude-anyteam';
@@ -41,6 +45,11 @@ const CLAUDE_PLUGIN_MANUAL_COMMANDS = [
 ];
 const CLAUDE_PLUGIN_MARKETPLACE_ALREADY_EXISTS = /\balready (?:on disk|exists)\b/i;
 const CLAUDE_PLUGIN_ALREADY_INSTALLED = /\balready installed\b/i;
+const PACKAGE_JSON = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8'));
+const INSTALLER_VERSION = PACKAGE_JSON.version || 'unknown';
+
+let detectedPythonVersion = 'not checked';
+let detectedUvVersion = 'not checked';
 
 function parseArgs(argv) {
   const args = { postinstall: false, settingsPath: undefined, help: false };
@@ -79,8 +88,8 @@ function usage() {
   ].join('\n');
 }
 
-async function confirmInstallUv() {
-  const prompt = `${theme.symbols.info} ${theme.heading('uv is missing.')} Install it now into ${theme.accent(UV_INSTALL_DIR)}? ${theme.muted('[Y/n] ')}`;
+async function confirmInstallDependency({ name, reason }) {
+  const prompt = `${theme.symbols.info} ${theme.heading(`${name} is missing.`)} ${reason} ${theme.muted('Want me to try installing it for you? [Y/n] ')}`;
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
   try {
     const answer = (await rl.question(prompt)).trim().toLowerCase();
@@ -105,9 +114,61 @@ async function withSpinner(text, enabled, action) {
   }
 }
 
-function printFailure(title, lines) {
+function issueContext(rawError) {
+  return {
+    installerVersion: INSTALLER_VERSION,
+    os: `${process.platform} ${release()} ${arch()}`,
+    pythonVersion: detectedPythonVersion,
+    uvVersion: detectedUvVersion,
+    nodeVersion: process.version,
+    rawError,
+  };
+}
+
+function fallbackNextSteps() {
+  return [
+    `Read the message above and follow the command it suggests.`,
+    `Re-run ${theme.accent('npx --yes claude-anyteam')} after that finishes.`,
+    `If the same error comes back, open the report link below so we can help.`,
+  ];
+}
+
+function hasGuidanceLine(lines) {
+  return lines.some((line) => /try this next|next step|install it|rerun|re-run|run these commands|run these commands/i.test(String(line)));
+}
+
+function diagnosticTail(title, rawError, options = {}) {
+  const context = issueContext(rawError);
+  return formatInstallerDiagnostic({
+    title,
+    summary: options.summary || title,
+    rawError,
+    nextStepsPerOs: options.nextStepsPerOs || fallbackNextSteps(),
+    ...context,
+    includeWhatHappened: options.includeWhatHappened ?? false,
+  }).map((line) => (line.startsWith('  ') ? `    ${theme.accent(line.trim())}` : `${theme.symbols.info} ${theme.heading(line)}`));
+}
+
+function printFailure(title, lines, options = {}) {
+  const body = [...lines];
+  const rawError = String(options.rawError || lines.join('\n'));
+  if (!hasGuidanceLine(body)) {
+    body.push('');
+    body.push(`${theme.symbols.info} ${theme.heading('Try this next')}:`);
+    body.push(...fallbackNextSteps().map((step, index) => `    ${index + 1}. ${step}`));
+  }
+  if (!body.some((line) => /Still stuck\? Report it/i.test(String(line)))) {
+    const tail = diagnosticTail(title, rawError, {
+      summary: options.summary,
+      nextStepsPerOs: options.nextStepsPerOs,
+      includeWhatHappened: false,
+    });
+    const stuckIndex = tail.findIndex((line) => /Still stuck\? Report it/i.test(String(line)));
+    body.push('');
+    body.push(...tail.slice(stuckIndex));
+  }
   console.error('');
-  console.error(renderBox(theme.danger(title), lines, 'red'));
+  console.error(renderBox(theme.danger(title), body, 'red'));
   console.error('');
 }
 
@@ -117,10 +178,37 @@ function printSuccess(lines) {
   console.log('');
 }
 
-function printWarning(title, lines) {
+function printWarning(title, lines, options = {}) {
+  const body = [...lines];
+  if (options.issue !== false) {
+    const rawError = String(options.rawError || lines.join('\n'));
+    const tail = diagnosticTail(title, rawError, {
+      summary: options.summary,
+      nextStepsPerOs: options.nextStepsPerOs,
+      includeWhatHappened: false,
+    });
+    const tryIndex = tail.findIndex((line) => /Try this next/i.test(String(line)));
+    if (!hasGuidanceLine(body) && tryIndex >= 0) {
+      const stuckIndex = tail.findIndex((line) => /Still stuck\? Report it/i.test(String(line)));
+      body.push('');
+      body.push(...tail.slice(tryIndex, stuckIndex));
+    }
+    const stuckIndex = tail.findIndex((line) => /Still stuck\? Report it/i.test(String(line)));
+    body.push('');
+    body.push(...tail.slice(stuckIndex));
+  }
   console.log('');
-  console.log(renderBox(theme.warn(title), lines, 'yellow'));
+  console.log(renderBox(theme.warn(title), body, 'yellow'));
   console.log('');
+}
+
+function printVersionBanner() {
+  console.log(theme.muted(`claude-anyteam installer v${INSTALLER_VERSION}`));
+}
+
+function printSection(title, detail) {
+  console.log('');
+  console.log(`${theme.symbols.info} ${theme.accent(title)} ${theme.muted(detail)}`);
 }
 
 function rawDetailsLines(raw) {
@@ -140,7 +228,9 @@ function translatedDiagnosticLines(translated, { command, recovered } = {}) {
   if (recovered) {
     lines.push(`${theme.symbols.success} ${theme.heading('Recovered')}: ${recovered}`);
   }
-  lines.push(`${theme.symbols.info} ${theme.heading('Next step')}: ${translated.action}`);
+  lines.push(`${theme.symbols.info} ${theme.heading('Try this next')}:`);
+  const actionLines = String(translated.action || 'Re-run the installer after fixing the problem.').split(/\r?\n/).filter(Boolean);
+  lines.push(...actionLines.map((line, index) => `    ${index + 1}. ${line}`));
   if (command) {
     lines.push(`${theme.symbols.info} ${theme.heading('Command')}: ${theme.accent(command)}`);
   }
@@ -197,7 +287,18 @@ function windowsAdviceLines(advice) {
 
 function postinstallHint(error) {
   const reason = trimmedDetails(error) || error.message;
-  console.warn(`claude-anyteam: automatic setup skipped (${reason.split(/\r?\n/, 1)[0]}). Run npx --yes claude-anyteam to finish.`);
+  const rawError = reason || 'automatic setup skipped';
+  const lines = [
+    `claude-anyteam: automatic setup skipped (${rawError.split(/\r?\n/, 1)[0]}).`,
+    ...formatInstallerDiagnostic({
+      title: 'Automatic setup skipped',
+      summary: 'npm could not finish claude-anyteam setup automatically.',
+      rawError,
+      nextStepsPerOs: ['Run `npx --yes claude-anyteam` in a normal terminal to finish setup.'],
+      ...issueContext(rawError),
+    }),
+  ];
+  console.warn(lines.join('\n'));
 }
 
 function claudePluginManualSummary() {
@@ -255,6 +356,7 @@ function runPythonInstaller({ uvPath, settingsPath, stdio = 'inherit' }) {
     '--no-config',
     'tool',
     'run',
+    '--prerelease=allow',
     '--from', TOOL_NAME,
     TOOL_NAME,
     'install',
@@ -265,7 +367,11 @@ function runPythonInstaller({ uvPath, settingsPath, stdio = 'inherit' }) {
   }
   return new Promise((resolve, reject) => {
     const child = spawn(uvPath, args, {
-      env: uvToolEnv(process.env),
+      env: {
+        ...uvToolEnv(process.env),
+        CLAUDE_ANYTEAM_NPM_PARENT: '1',
+        CLAUDE_ANYTEAM_NPM_VERSION: INSTALLER_VERSION,
+      },
       stdio,
     });
     child.on('error', reject);
@@ -328,27 +434,80 @@ async function main() {
   const postinstall = args.postinstall || process.env.npm_lifecycle_event === 'postinstall';
   const interactive = isInteractive();
   const silent = postinstall;
+  const nodeMajor = Number.parseInt(process.versions.node.split('.', 1)[0] || '0', 10);
 
   if (!silent) {
     console.log(renderBanner());
-    console.log(theme.heading('Zero-friction claude-anyteam setup for Claude Code.'));
-    console.log(theme.muted('We will check Python, install uv if needed, wire up claude-anyteam, patch Claude settings, and register the Claude plugin.'));
+    printVersionBanner();
+    console.log(theme.heading('Friendly claude-anyteam setup for Claude Code.'));
+    console.log(theme.muted('I will check the tools you need, offer to install anything missing, wire up Claude Code, and keep the raw details visible if something breaks.'));
     console.log('');
+    printSection('1/3 Detect', 'First I check what is already on this computer.');
   }
 
-  const pythonCheck = await detectPython({ diagnostics: true });
-  const python = pythonCheck.python;
+  if (nodeMajor < 18) {
+    if (silent) {
+      postinstallHint(new Error(`Node.js ${process.versions.node} is too old; Node.js 18+ is required`));
+      return 0;
+    }
+    printFailure('NODE.JS VERSION TOO OLD', [
+      `${theme.symbols.error} ${theme.heading(`This installer is running on Node.js ${process.versions.node}, but it needs Node.js 18 or newer.`)}`,
+      `${theme.symbols.info} Node.js is the JavaScript runtime that runs npx. Install the current LTS version, then rerun ${theme.accent('npx --yes claude-anyteam')}.`,
+      '',
+      ...nodeInstallLines().map((line) => `${theme.symbols.info} ${line}`),
+    ], { rawError: `Node.js ${process.versions.node} < 18` });
+    return 1;
+  }
+
+  let pythonCheck = await detectPython({ diagnostics: true });
+  let python = pythonCheck.python;
+  detectedPythonVersion = python?.version || 'not found';
   if (!python) {
     if (silent) {
       postinstallHint(new Error(`${pythonLabel()} was not found`));
       return 0;
     }
+    let shouldInstall = false;
+    if (!interactive) {
+      printWarning('SKIPPING PYTHON AUTO-INSTALL', [
+        `${theme.symbols.info} I cannot ask questions because this terminal is non-interactive (for example, stdin is piped or CI is running).`,
+        `${theme.symbols.info} Please install Python manually using the steps below, then rerun ${theme.accent('npx --yes claude-anyteam')}.`,
+      ]);
+    } else {
+      shouldInstall = await confirmInstallDependency({
+        name: 'Python 3.12+',
+        reason: 'Python is the programming language that runs claude-anyteam.',
+      });
+    }
+    if (shouldInstall) {
+      try {
+        python = await withSpinner('Installing Python 3.12+ with your system package manager', !silent, () => installPython());
+        pythonCheck = { python, issue: null };
+        detectedPythonVersion = python.version || 'unknown';
+      } catch (error) {
+        const translated = pythonMissingTranslation(pythonCheck.issue);
+        printFailure('PYTHON INSTALL FAILED', [
+          `${theme.symbols.error} ${theme.heading('I tried to install Python, but the computer would not let me finish.')}`,
+          `${theme.symbols.info} Installer output: ${trimmedDetails(error) || 'No extra diagnostics.'}`,
+          '',
+          `${theme.symbols.info} ${theme.heading('Try this next')}:`,
+          ...manualInstallLines({ includePython: true }).map((line, index) => `    ${index + 1}. ${line}`),
+          '',
+          ...translatedDiagnosticLines(translated),
+        ], { rawError: trimmedDetails(error) || String(error) });
+        return 1;
+      }
+    }
+  }
+
+  if (!python) {
     const translated = pythonMissingTranslation(pythonCheck.issue);
     printFailure('PYTHON 3.12+ NOT FOUND', [
+      `${theme.symbols.warn} ${theme.heading('We need Python 3.12 or newer because claude-anyteam is a Python tool.')}`,
       ...translatedDiagnosticLines(translated),
       '',
       ...manualInstallLines({ includePython: true }).map((line) => `${theme.symbols.info} ${line}`),
-    ]);
+    ], { rawError: translated.raw });
     return 1;
   }
 
@@ -361,63 +520,93 @@ async function main() {
       postinstallHint(new Error(`Python ${python.version} is too old; Python 3.12+ is required`));
       return 0;
     }
+    if (interactive && await confirmInstallDependency({
+      name: 'a newer Python',
+      reason: `I found Python ${python.version}, but claude-anyteam needs Python 3.12 or newer.`,
+    })) {
+      try {
+        python = await withSpinner('Installing a newer Python 3.12+', !silent, () => installPython());
+        detectedPythonVersion = python.version || 'unknown';
+      } catch (error) {
+        const translated = translate({
+          raw: `Detected Python ${python.version} at ${formatDisplayPath(python.path)}\n${trimmedDetails(error)}`,
+          pythonVersion: python.version,
+        });
+        printFailure('PYTHON UPGRADE FAILED', [
+          ...translatedDiagnosticLines(translated),
+          '',
+          ...manualInstallLines({ includePython: true }).map((line) => `${theme.symbols.info} ${line}`),
+        ], { rawError: translated.raw });
+        return 1;
+      }
+      if (!isPythonVersionTooOld(python.version)) {
+        console.log(`${theme.symbols.success} ${theme.heading(`${pythonLabel()} updated`)} ${theme.muted(`(${python.version})`)} ${theme.accent(formatDisplayPath(python.path))}`);
+      }
+    }
+  }
+
+  if (isPythonVersionTooOld(python.version)) {
     const translated = translate({
       raw: `Detected Python ${python.version} at ${formatDisplayPath(python.path)}`,
       pythonVersion: python.version,
     });
-    printFailure('PYTHON VERSION TOO OLD', translatedDiagnosticLines(translated));
+    printFailure('PYTHON VERSION TOO OLD', translatedDiagnosticLines(translated), { rawError: translated.raw });
     return 1;
   }
 
   let uv = await detectUv();
+  detectedUvVersion = uv?.version || 'not found';
   if (!uv) {
-    if (process.platform === 'win32') {
-      if (silent) {
-        postinstallHint(new Error('uv is not installed'));
-        return 0;
-      }
-      printFailure('UV NOT INSTALLED', [
-        `${theme.symbols.warn} ${theme.heading('uv is required to install the Python claude-anyteam tool.')}`,
-        `${theme.symbols.info} Install it from PowerShell, then rerun ${theme.accent('npx --yes claude-anyteam')}.`,
-        '',
-        ...manualInstallLines().map((line) => `${theme.symbols.info} ${line}`),
-      ]);
-      return 1;
+    if (silent) {
+      postinstallHint(new Error('uv is not installed'));
+      return 0;
     }
-    const autoInstall = postinstall || !interactive || (await confirmInstallUv());
+
+    let autoInstall = false;
+    if (!interactive) {
+      printWarning('SKIPPING UV AUTO-INSTALL', [
+        `${theme.symbols.info} I cannot ask questions because this terminal is non-interactive (for example, stdin is piped or CI is running).`,
+        `${theme.symbols.info} Please install uv manually using the steps below, then rerun ${theme.accent('npx --yes claude-anyteam')}.`,
+      ]);
+    } else {
+      autoInstall = await confirmInstallDependency({
+        name: 'uv',
+        reason: 'uv is the small installer that downloads and runs the Python claude-anyteam tool.',
+      });
+    }
+
     if (!autoInstall) {
-      if (silent) {
-        postinstallHint(new Error('uv is not installed'));
-        return 0;
-      }
       printFailure('UV NOT INSTALLED', [
-        `${theme.symbols.warn} ${theme.heading('uv is required to install the Python claude-anyteam tool.')}`,
-        `${theme.symbols.info} Install it manually, then rerun ${theme.accent('npx --yes claude-anyteam')}.`,
+        `${theme.symbols.warn} ${theme.heading('uv is required because it installs claude-anyteam safely in its own Python environment.')}`,
+        `${theme.symbols.info} Install uv manually, then rerun ${theme.accent('npx --yes claude-anyteam')}.`,
         '',
         ...manualInstallLines().map((line) => `${theme.symbols.info} ${line}`),
-      ]);
+      ], { rawError: 'uv was not found on PATH' });
       return 1;
     }
 
     try {
       uv = await withSpinner(`Installing uv into ${UV_INSTALL_DIR}`, !silent, () => installUv());
+      detectedUvVersion = uv.version || 'unknown';
     } catch (error) {
       if (silent) {
         postinstallHint(error);
         return 0;
       }
       printFailure('UV INSTALL FAILED', [
-        `${theme.symbols.error} ${theme.heading('Automatic uv installation did not complete.')}`,
+        `${theme.symbols.error} ${theme.heading('I tried to install uv, but the computer would not let me finish.')}`,
         `${theme.symbols.info} Installer output: ${trimmedDetails(error) || 'No extra diagnostics.'}`,
         '',
         ...manualInstallLines().map((line) => `${theme.symbols.info} ${line}`),
-      ]);
+      ], { rawError: trimmedDetails(error) || String(error) });
       return 1;
     }
   }
 
   if (!silent) {
+    detectedUvVersion = uv.version || 'unknown';
     console.log(`${theme.symbols.success} ${theme.heading('uv ready')} ${theme.muted(uv.version)} ${theme.accent(formatDisplayPath(uv.path))}`);
+    printSection('2/3 Install', 'Now I install or reuse the claude-anyteam command.');
   }
 
   if (process.platform === 'win32') {
@@ -431,8 +620,8 @@ async function main() {
       printWarning('WINDOWS LONG PATHS MAY BE DISABLED', [
         `${theme.symbols.warn} ${theme.heading('uv tool install can exceed the default 260-character Windows path limit.')}`,
         `${theme.symbols.info} Automatic registry update did not succeed: ${trimmedDetails(longPaths) || 'No extra diagnostics.'}`,
-        `${theme.symbols.info} Next step: open PowerShell as Administrator and run:`,
-        `    ${theme.accent(powershellLongPathsCommand())}`,
+        `${theme.symbols.info} ${theme.heading('Try this next')}:`,
+        `    1. Open PowerShell as Administrator and run: ${theme.accent(powershellLongPathsCommand())}`,
       ]);
     }
   }
@@ -464,7 +653,7 @@ async function main() {
       printFailure('TOOL INSTALL FAILED', [
         ...translatedDiagnosticLines(translatedForDisplay, { command }),
         ...(advice.length ? ['', ...windowsAdviceLines(advice)] : []),
-      ]);
+      ], { rawError: translated.raw || trimmedDetails(error) || error.message });
       return 1;
     }
   }
@@ -474,6 +663,7 @@ async function main() {
   // status lines to stdout, and overlaying a spinner would fight with that output.
   if (!silent) {
     console.log('');
+    printSection('3/3 Wire up', 'Now I connect claude-anyteam to Claude Code settings.');
     const pythonInstallerSummary = process.platform === 'win32'
       ? `— Windows single-terminal compatibility, Codex/Gemini/Kimi CLI prereq checks, ${settingsDisplayPath()}, ${claudeJsonDisplayPath()}, install-state.json`
       : `— tmux + Codex/Gemini/Kimi CLI prereq checks, ${settingsDisplayPath()}, ${claudeJsonDisplayPath()}, install-state.json`;
@@ -499,7 +689,7 @@ async function main() {
       `${theme.symbols.info} Details: ${trimmedDetails(error) || error.message}`,
       `${theme.symbols.info} Retry with ${theme.accent(formatCommand(tool.binaryPath, ['install', '--assume-yes']))} after ensuring uv is on PATH.`,
       ...windowsAdviceLines(windowsAdvice(error, { binDir: tool.binDir })),
-    ]);
+    ], { rawError: trimmedDetails(error) || error.message });
     return 1;
   }
   if (installerResult.code !== 0) {
@@ -511,7 +701,10 @@ async function main() {
     // install hints, teammateMode conflict explanation, etc.) through
     // inherited stderr. Do not re-wrap; exit non-zero quietly.
     if (installerResult.code === 3) {
-      console.error(`${theme.symbols.warn} Python installer aborted (exit code 3) despite --assume-yes. This is unexpected — please file a bug at https://github.com/JonathanRosado/claude-anyteam/issues`);
+      printFailure('PYTHON INSTALLER ABORTED', [
+        `${theme.symbols.warn} The Python installer stopped with exit code 3 even though the npm wrapper passed --assume-yes.`,
+        `${theme.symbols.info} This is probably a real installer bug, not something you did wrong.`,
+      ], { rawError: `Python installer exited with code ${installerResult.code}` });
     }
     return 1;
   }
@@ -584,7 +777,7 @@ main().then(
     printFailure('UNEXPECTED INSTALLER ERROR', [
       `${theme.symbols.error} ${theme.heading(error.message)}`,
       ...(trimmedDetails(error) && trimmedDetails(error) !== error.message ? [`${theme.symbols.info} ${trimmedDetails(error)}`] : []),
-    ]);
+    ], { rawError: trimmedDetails(error) || error.stack || error.message });
     process.exitCode = 1;
   },
 );

--- a/npm/lib/art.js
+++ b/npm/lib/art.js
@@ -27,6 +27,7 @@ const borderPalette = {
   blue: colors.blue,
 };
 const headerGradient = gradient(['#22d3ee', '#60a5fa', '#a78bfa', '#f472b6']);
+const shortBanner = 'claude-anyteam';
 
 export const theme = {
   colors,
@@ -44,7 +45,11 @@ export const theme = {
   },
 };
 
-export function renderBanner() {
+export function renderBanner(options = {}) {
+  const columns = Number(options.columns ?? process.env.COLUMNS ?? process.stdout?.columns ?? 80);
+  if (Number.isFinite(columns) && columns > 0 && columns < 82) {
+    return headerGradient(shortBanner);
+  }
   return headerGradient.multiline(banner);
 }
 

--- a/npm/lib/art.js
+++ b/npm/lib/art.js
@@ -57,11 +57,75 @@ export function stripAnsi(value) {
   return String(value ?? '').replace(ansiPattern, '');
 }
 
+const BOX_MAX_WIDTH = 96;
+const BOX_MIN_WIDTH = 40;
+
+function wrapAnsiLine(rawRow, width) {
+  if (stripAnsi(rawRow).length <= width) return [rawRow];
+  const tokens = String(rawRow).split(/(\s+)/);
+  const lines = [];
+  let current = '';
+  let currentVisible = 0;
+  const flush = () => {
+    if (current.length > 0) lines.push(current);
+    current = '';
+    currentVisible = 0;
+  };
+  for (const tok of tokens) {
+    const tokVisible = stripAnsi(tok).length;
+    if (tokVisible === 0) continue;
+    if (tokVisible > width) {
+      flush();
+      let remaining = tok;
+      while (stripAnsi(remaining).length > width) {
+        let cut = 0, visible = 0;
+        for (const ch of remaining) {
+          if (ch === '') {
+            const m = remaining.slice(cut).match(/^\[[0-?]*[ -/]*[@-~]/);
+            if (m) { cut += m[0].length; continue; }
+          }
+          if (visible >= width) break;
+          cut += ch.length;
+          visible += 1;
+        }
+        lines.push(remaining.slice(0, cut));
+        remaining = remaining.slice(cut);
+      }
+      if (stripAnsi(remaining).length > 0) {
+        current = remaining;
+        currentVisible = stripAnsi(remaining).length;
+      }
+      continue;
+    }
+    if (currentVisible + tokVisible > width) {
+      flush();
+      if (/^\s+$/.test(tok)) continue;
+    }
+    current += tok;
+    currentVisible += tokVisible;
+  }
+  flush();
+  return lines.length > 0 ? lines : [rawRow];
+}
+
 export function renderBox(title, lines, color = 'cyan') {
   const paint = borderPalette[color] ?? ((value) => value);
-  const bodyRows = (Array.isArray(lines) ? lines : [lines]).flatMap((row) => String(row).split('\n'));
-  const rows = [String(title), ...bodyRows];
+  const termCols = Number(process.env.COLUMNS ?? process.stdout?.columns ?? 80);
+  const budget = Math.max(BOX_MIN_WIDTH, Math.min(BOX_MAX_WIDTH, (Number.isFinite(termCols) ? termCols : 80) - 4));
+  const bodyRows = (Array.isArray(lines) ? lines : [lines])
+    .flatMap((row) => String(row).split('\n'))
+    .flatMap((row) => wrapAnsiLine(row, budget));
+  const titleRows = wrapAnsiLine(String(title), budget);
+  const rows = [...titleRows, ...bodyRows];
   const width = Math.max(...rows.map((row) => stripAnsi(row).length), 0);
   const fill = (row) => `${row}${' '.repeat(width - stripAnsi(row).length)}`;
-  return [paint(`╭${'─'.repeat(width + 2)}╮`), `${paint('│')} ${fill(rows[0])} ${paint('│')}`, paint(`├${'─'.repeat(width + 2)}┤`), ...rows.slice(1).map((row) => `${paint('│')} ${fill(row)} ${paint('│')}`), paint(`╰${'─'.repeat(width + 2)}╯`)].join('\n');
+  const headerLines = titleRows.map((row) => `${paint('│')} ${fill(row)} ${paint('│')}`);
+  const bodyLines = bodyRows.map((row) => `${paint('│')} ${fill(row)} ${paint('│')}`);
+  return [
+    paint(`╭${'─'.repeat(width + 2)}╮`),
+    ...headerLines,
+    paint(`├${'─'.repeat(width + 2)}┤`),
+    ...bodyLines,
+    paint(`╰${'─'.repeat(width + 2)}╯`),
+  ].join('\n');
 }

--- a/npm/lib/detect.js
+++ b/npm/lib/detect.js
@@ -114,6 +114,7 @@ export function manualInstallLines({ includePython = false } = {}) {
   if (process.platform === 'win32') {
     if (includePython) {
       lines.push('PowerShell: winget install Python.Python.3.12');
+      lines.push('If winget is not available, download Python 3.12+ from https://www.python.org/downloads/ and tick “Add python.exe to PATH”.');
     }
     lines.push('PowerShell (preferred): winget install Astral-sh.uv');
     // winget ships on Windows 10 1709+ but corporate-locked images often
@@ -133,6 +134,28 @@ export function manualInstallLines({ includePython = false } = {}) {
   lines.push(`  UV_INSTALL_DIR=${UV_INSTALL_DIR} UV_NO_MODIFY_PATH=1 sh /tmp/uv-install.sh`);
   lines.push('Then rerun: npx --yes --package claude-anyteam claude-anyteam-setup');
   return lines;
+}
+
+export function nodeInstallLines() {
+  if (process.platform === 'win32') {
+    return [
+      'Install Node.js LTS from https://nodejs.org/ (it includes npm).',
+      'Then close and reopen PowerShell and rerun: npx --yes claude-anyteam',
+    ];
+  }
+  if (process.platform === 'darwin') {
+    return [
+      'macOS/Homebrew: brew install node',
+      'Or download Node.js LTS from https://nodejs.org/',
+      'Then rerun: npx --yes claude-anyteam',
+    ];
+  }
+  return [
+    'Debian/Ubuntu: sudo apt-get update && sudo apt-get install -y nodejs npm',
+    'Fedora/RHEL:   sudo dnf install nodejs npm',
+    'Arch:          sudo pacman -S nodejs npm',
+    'Then rerun: npx --yes claude-anyteam',
+  ];
 }
 
 export function providerPrereqLines() {
@@ -298,7 +321,54 @@ export async function detectUv() {
 
 export async function installUv() {
   if (process.platform === 'win32') {
-    throw new Error('Automatic uv installation uses the official shell installer on macOS/Linux. On Windows, install uv from PowerShell with: `winget install Astral-sh.uv` (preferred) — or, if winget is unavailable on your image, `irm https://astral.sh/uv/install.ps1 | iex` (no admin or winget required).');
+    const attempts = [
+      { command: 'winget', args: ['install', '--id', 'Astral-sh.uv', '-e', '--accept-package-agreements', '--accept-source-agreements'] },
+      { command: 'scoop', args: ['install', 'uv'] },
+      { command: 'choco', args: ['install', 'uv', '-y'] },
+    ];
+    const failures = [];
+    for (const attempt of attempts) {
+      if (!(await which(attempt.command))) {
+        failures.push(`${attempt.command}: not found`);
+        continue;
+      }
+      const result = await runCommand(attempt.command, attempt.args, { env: process.env });
+      if (result.code === 0) {
+        const installed = await detectUv();
+        if (installed) {
+          return installed;
+        }
+        failures.push(`${attempt.command}: completed, but uv was not found on PATH yet`);
+      } else {
+        failures.push(`${attempt.command}: ${(result.stderr || result.stdout).trim() || `exit ${result.code}`}`);
+      }
+    }
+
+    const shell = await which('pwsh') || await which('powershell.exe') || await which('powershell');
+    if (shell) {
+      const result = await runCommand(shell, [
+        '-NoProfile',
+        '-ExecutionPolicy',
+        'Bypass',
+        '-Command',
+        'irm https://astral.sh/uv/install.ps1 | iex',
+      ], { env: { ...process.env, UV_INSTALL_DIR } });
+      if (result.code === 0) {
+        const installed = await detectUv();
+        if (installed) {
+          return installed;
+        }
+        failures.push('official PowerShell installer: completed, but uv was not found on PATH yet');
+      } else {
+        failures.push(`official PowerShell installer: ${(result.stderr || result.stdout).trim() || `exit ${result.code}`}`);
+      }
+    } else {
+      failures.push('PowerShell: not found');
+    }
+
+    const error = new Error('Automatic uv installation did not finish on Windows.');
+    error.details = failures.join('\n');
+    throw error;
   }
   const workingDir = await fs.mkdtemp(path.join(tmpdir(), 'claude-anyteam-uv-'));
   const scriptPath = path.join(workingDir, 'install-uv.sh');
@@ -330,6 +400,52 @@ export async function installUv() {
   } finally {
     await fs.rm(workingDir, { recursive: true, force: true });
   }
+}
+
+export async function installPython() {
+  const attempts = [];
+  if (process.platform === 'win32') {
+    attempts.push(
+      { command: 'winget', args: ['install', '--id', 'Python.Python.3.12', '-e', '--accept-package-agreements', '--accept-source-agreements'] },
+      { command: 'scoop', args: ['install', 'python'] },
+      { command: 'choco', args: ['install', 'python', '-y'] },
+    );
+  } else if (process.platform === 'darwin') {
+    attempts.push({ command: 'brew', args: ['install', 'python'] });
+  } else {
+    attempts.push(
+      { command: 'apt-get', args: ['update'] },
+      { command: 'apt-get', args: ['install', '-y', 'python3', 'python3-venv', 'curl'] },
+      { command: 'dnf', args: ['install', '-y', 'python3', 'curl'] },
+      { command: 'pacman', args: ['-S', '--noconfirm', 'python', 'curl'] },
+    );
+  }
+
+  const failures = [];
+  for (const attempt of attempts) {
+    if (!(await which(attempt.command))) {
+      failures.push(`${attempt.command}: not found`);
+      continue;
+    }
+    const command = process.platform === 'win32' || process.platform === 'darwin'
+      ? attempt.command
+      : (process.getuid?.() === 0 ? attempt.command : (await which('sudo') ? 'sudo' : attempt.command));
+    const args = command === attempt.command ? attempt.args : [attempt.command, ...attempt.args];
+    const result = await runCommand(command, args, { env: process.env });
+    if (result.code !== 0) {
+      failures.push(`${command} ${args.join(' ')}: ${(result.stderr || result.stdout).trim() || `exit ${result.code}`}`);
+      continue;
+    }
+    const detected = await detectPython();
+    if (detected) {
+      return detected;
+    }
+    failures.push(`${command} ${args.join(' ')}: completed, but Python was not found on PATH yet`);
+  }
+
+  const error = new Error('Automatic Python installation did not finish.');
+  error.details = failures.join('\n');
+  throw error;
 }
 
 function toolExecutablePath(binDir, name) {

--- a/npm/lib/error-translator.js
+++ b/npm/lib/error-translator.js
@@ -1,3 +1,5 @@
+import { arch, release } from 'node:os';
+
 const ISSUE_URL = 'https://github.com/JonathanRosado/claude-anyteam/issues/new';
 const PYTHON_DOWNLOADS_URL = 'https://www.python.org/downloads/';
 const CLAUDE_CODE_SETUP_URL = 'https://docs.claude.com/en/docs/claude-code/setup';
@@ -102,7 +104,7 @@ export const patterns = [
     match: (raw) => prereleaseBlocked(raw),
     render: () => ({
       title: 'Pre-release dependency blocked by uv',
-      explanation: 'We use a pre-release Python dependency, and uv refused to resolve it without explicit pre-release opt-in.',
+      explanation: 'claude-anyteam uses a beta Python package (a pre-release dependency), and uv refused to install beta packages until we explicitly allow them.',
       action: 'Re-run with `npx --yes claude-anyteam@latest`. If it still fails, run `uv tool install --prerelease=allow claude-anyteam`.',
       severity: HARD,
     }),
@@ -112,8 +114,8 @@ export const patterns = [
     match: (raw) => NO_SOLUTION.test(raw.text) && !prereleaseBlocked(raw),
     render: () => ({
       title: 'Python dependency conflict',
-      explanation: 'uv could not find a compatible set of Python dependencies. Most often, another installed tool pinned an incompatible dependency version.',
-      action: 'Run `uv tool install --reinstall claude-anyteam`, then re-run `npx --yes claude-anyteam@latest`.',
+      explanation: 'uv could not find Python packages that work together. Most often, another installed tool is asking for a different version of the same package.',
+      action: 'Run `uv tool install --reinstall --prerelease=allow claude-anyteam`, then re-run `npx --yes claude-anyteam@latest`.',
       severity: HARD,
     }),
   },
@@ -142,7 +144,7 @@ export const patterns = [
     match: (raw) => CORPORATE_PROXY.test(raw.text) && !NETWORK_TIMEOUT.test(raw.text),
     render: () => ({
       title: 'Corporate proxy blocked PyPI',
-      explanation: "uv couldn't reach PyPI through your corporate network.",
+      explanation: "uv couldn't reach PyPI (the website where Python packages are downloaded) through your corporate network.",
       action: 'Set the proxy explicitly: `HTTPS_PROXY=http://your.proxy:port HTTP_PROXY=$HTTPS_PROXY UV_HTTP_TIMEOUT=120 npx --yes claude-anyteam`. Confirm with `curl -I https://pypi.org`.',
       severity: HARD,
     }),
@@ -192,7 +194,7 @@ export const patterns = [
     match: (raw) => PYTHON_MISSING.test(raw.text),
     render: () => ({
       title: 'Python 3.12+ not found',
-      explanation: 'uv could not find a Python 3.12+ interpreter to install claude-anyteam. Kimi teammates additionally require Python 3.13 for the separate `kimi-cli` uv tool.',
+      explanation: 'uv could not find Python 3.12 or newer to install claude-anyteam. Kimi teammates additionally require Python 3.13 for the separate `kimi-cli` uv tool.',
       action: 'Install Python 3.12+ from https://www.python.org/downloads/ (Windows: tick “Add to PATH”) or run `uv python install 3.12`. For Kimi teammates, also run `uv python install 3.13`.',
       severity: HARD,
     }),
@@ -232,7 +234,7 @@ export const patterns = [
     match: (raw) => NETWORK.test(raw.text),
     render: () => ({
       title: 'Network problem reaching PyPI',
-      explanation: 'uv could not reach the Python package index (PyPI), likely because of a proxy, VPN, DNS, TLS, or temporary network issue.',
+      explanation: 'uv could not reach PyPI (the website where Python packages are downloaded), likely because of a proxy, VPN, DNS, TLS certificate, or temporary network issue.',
       action: 'Set `HTTPS_PROXY` and `HTTP_PROXY` if needed, then re-run `npx --yes claude-anyteam@latest`; if you are on a VPN, try disconnecting briefly.',
       severity: HARD,
     }),
@@ -308,7 +310,7 @@ export const patterns = [
     match: (raw) => raw.kind === 'claude-not-found' || CLAUDE_NOT_FOUND.test(raw.text),
     render: () => ({
       title: 'Claude Code CLI not detected',
-      explanation: 'The installer skipped Claude Code plugin registration because `claude` was not available on PATH; the core spawn shim install can still be used.',
+      explanation: 'The installer skipped Claude Code plugin registration because the `claude` command was not available on PATH (the list of folders your terminal searches for commands). The core spawn shim install can still be used.',
       action: 'Install Claude Code from https://docs.claude.com/en/docs/claude-code/setup and re-run, or proceed without the plugin by symlinking the spawn shim from your editor.',
       severity: SOFT,
     }),
@@ -347,11 +349,109 @@ export function translate(rawError, context = {}) {
     action: rendered.action,
     severity: rendered.severity,
     raw: raw.text,
+    issueUrl: buildIssueUrl({ title: rendered.title, rawError: raw.text }),
   };
 }
 
 export const translateInstallError = translate;
 export default translate;
+
+export function buildIssueUrl({
+  title = 'Installer error',
+  installerVersion = 'unknown',
+  os = `${process.platform} ${release()} ${arch()}`,
+  pythonVersion = 'not checked',
+  uvVersion = 'not checked',
+  nodeVersion = process.version,
+  rawError = '',
+  whatDoing = 'I was running `npx --yes claude-anyteam`.',
+} = {}) {
+  const body = [
+    '## What I was doing',
+    whatDoing,
+    '',
+    '## Installer details',
+    `- Installer version: ${installerVersion}`,
+    `- OS: ${os}`,
+    `- Python version: ${pythonVersion || 'not checked'}`,
+    `- uv version: ${uvVersion || 'not checked'}`,
+    `- Node version: ${nodeVersion || process.version}`,
+    '',
+    '## Raw error text',
+    '```text',
+    String(rawError || 'No raw error captured.'),
+    '```',
+  ].join('\n');
+  const params = new URLSearchParams({
+    title: `[installer] ${String(title).slice(0, 120)}`,
+    body,
+  });
+  return `${ISSUE_URL}?${params.toString()}`;
+}
+
+function normalizeSteps(nextStepsPerOs = [], platform = process.platform) {
+  if (Array.isArray(nextStepsPerOs)) {
+    return nextStepsPerOs;
+  }
+  if (typeof nextStepsPerOs === 'string') {
+    return nextStepsPerOs.split(/\r?\n/).filter(Boolean);
+  }
+  if (nextStepsPerOs && typeof nextStepsPerOs === 'object') {
+    if (platform === 'win32' && nextStepsPerOs.win32) {
+      return normalizeSteps(nextStepsPerOs.win32, platform);
+    }
+    if (platform === 'darwin' && nextStepsPerOs.darwin) {
+      return normalizeSteps(nextStepsPerOs.darwin, platform);
+    }
+    if (!['win32', 'darwin'].includes(platform) && nextStepsPerOs.linux) {
+      return normalizeSteps(nextStepsPerOs.linux, platform);
+    }
+    return normalizeSteps(nextStepsPerOs.default || [], platform);
+  }
+  return [];
+}
+
+export function formatInstallerDiagnostic({
+  summary = 'The installer hit a problem.',
+  rawError = '',
+  nextStepsPerOs = [],
+  title = 'Installer error',
+  installerVersion = 'unknown',
+  os = `${process.platform} ${release()} ${arch()}`,
+  platform = process.platform,
+  pythonVersion = 'not checked',
+  uvVersion = 'not checked',
+  nodeVersion = process.version,
+  whatDoing = 'I was running `npx --yes claude-anyteam`.',
+  includeWhatHappened = true,
+} = {}) {
+  const steps = normalizeSteps(nextStepsPerOs, platform);
+  const safeSteps = steps.length
+    ? steps
+    : [
+        'Read the message above.',
+        'Fix the problem it describes.',
+        'Run `npx --yes claude-anyteam` again.',
+      ];
+  const lines = [];
+  if (includeWhatHappened) {
+    lines.push(`What happened: ${summary}`);
+  }
+  lines.push('Try this next:');
+  lines.push(...safeSteps.map((step, index) => `  ${index + 1}. ${step}`));
+  lines.push('Still stuck? Report it:');
+  lines.push(`  ${buildIssueUrl({
+    title,
+    installerVersion,
+    os,
+    pythonVersion,
+    uvVersion,
+    nodeVersion,
+    rawError,
+    whatDoing,
+  })}`);
+  return lines;
+}
 
 export const urls = {
   issues: ISSUE_URL,

--- a/src/claude_anyteam/cli.py
+++ b/src/claude_anyteam/cli.py
@@ -8,12 +8,19 @@ persistent settings file.
 from __future__ import annotations
 
 import argparse
+import importlib.metadata
+import os
+import platform
+import shutil
+import subprocess
 import sys
 from pathlib import Path
 from typing import TextIO
+from urllib.parse import urlencode
 
 from . import logger
 from .config import from_env
+from claude_anyteam import installer as installer_mod
 from claude_anyteam.installer import (
     INSTALL_ERROR_EXIT_NO_PROVIDER,
     InstallError,
@@ -23,6 +30,8 @@ from claude_anyteam.installer import (
     uninstall as uninstall_settings,
 )
 from .loop import run
+
+ISSUE_NEW_URL = "https://github.com/JonathanRosado/claude-anyteam/issues/new"
 
 
 def _bold(text: str) -> str:
@@ -52,12 +61,61 @@ def _render_box(title: str, lines: list[str]) -> str:
     )
 
 
+def _installer_version() -> str:
+    env_version = os.environ.get("CLAUDE_ANYTEAM_NPM_VERSION")
+    if env_version:
+        return env_version
+    try:
+        return importlib.metadata.version("claude-anyteam")
+    except importlib.metadata.PackageNotFoundError:
+        pyproject = Path(__file__).resolve().parents[2] / "pyproject.toml"
+        try:
+            for line in pyproject.read_text(encoding="utf-8").splitlines():
+                if line.startswith("version = "):
+                    return line.split("=", 1)[1].strip().strip('"')
+        except OSError:
+            pass
+    return "unknown"
+
+
+def _version_banner() -> str:
+    return f"claude-anyteam installer v{_installer_version()}"
+
+
+def _command_version(command: str) -> str:
+    path = shutil.which(command)
+    if not path:
+        return "not found"
+    try:
+        completed = subprocess.run(
+            [path, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=3,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return f"found at {path}, but version check failed: {exc}"
+    return (completed.stdout or completed.stderr or "").strip() or f"found at {path}"
+
+
+def _issue_url(*, title: str, raw_error: str) -> str:
+    return installer_mod.build_issue_url(title=title, raw_error=raw_error)
+
+
 def _format_install_error(exc: InstallError) -> str:
     lines: list[str] = [_bold(exc.title)]
     lines.extend(exc.explanation.splitlines() or [""])
-    for idx, line in enumerate(exc.action.splitlines() or [""]):
-        prefix = "Next step: " if idx == 0 else "           "
-        lines.append(f"{prefix}{line}")
+    raw_error = exc.as_plain_text(include_details=True, include_report=False)
+    lines.extend(
+        installer_mod.format_installer_diagnostic(
+            summary=exc.explanation,
+            raw_error=raw_error,
+            next_steps_per_os=exc.action,
+            title=exc.title,
+            include_what_happened=False,
+        )
+    )
     lines.append(f"Severity: {exc.severity}")
     if exc.details:
         lines.append("Raw details (for debugging):")
@@ -254,6 +312,126 @@ def _interactive_prompt(current_value: str) -> bool:
     return answer.strip().lower() in {"y", "yes"}
 
 
+def _yes_default_prompt(question: str) -> bool | None:
+    if not (sys.stdin.isatty() and sys.stdout.isatty()):
+        return None
+    try:
+        answer = input(f"{question} [Y/n] ")
+    except EOFError:
+        return None
+    return answer.strip().lower() not in {"n", "no"}
+
+
+def _run_install_command(args: list[str], *, timeout_s: int = 300) -> tuple[bool, str]:
+    try:
+        completed = subprocess.run(
+            args,
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return False, f"{type(exc).__name__}: {exc}"
+    output = "\n".join(
+        part for part in ((completed.stdout or "").strip(), (completed.stderr or "").strip()) if part
+    )
+    return completed.returncode == 0, output or f"exit code {completed.returncode}"
+
+
+def _provider_install_command(provider_key: str) -> tuple[str, list[str]] | None:
+    if provider_key == "codex":
+        npm = shutil.which("npm")
+        if npm:
+            return installer_mod.CODEX_CLI_INSTALL_COMMAND, [npm, "install", "-g", "@openai/codex"]
+        return None
+    if provider_key == "gemini":
+        npm = shutil.which("npm")
+        if npm:
+            return installer_mod.GEMINI_CLI_INSTALL_COMMAND, [npm, "install", "-g", "@google/gemini-cli"]
+        return None
+    if provider_key == "kimi":
+        uv = shutil.which("uv")
+        if uv:
+            return installer_mod.KIMI_CLI_INSTALL_COMMAND, [uv, "tool", "install", "--python", "3.13", "kimi-cli"]
+        if sys.platform != "win32" and shutil.which("sh") and shutil.which("curl"):
+            return installer_mod.KIMI_CLI_CURL_INSTALL_COMMAND, ["sh", "-lc", installer_mod.KIMI_CLI_CURL_INSTALL_COMMAND]
+    return None
+
+
+def _manual_provider_steps(provider_key: str) -> list[str]:
+    if provider_key == "codex":
+        return [
+            f"Install Node.js/npm if needed: https://nodejs.org/",
+            f"Install Codex: {installer_mod.CODEX_CLI_INSTALL_COMMAND}",
+            f"Sign in: {installer_mod.CODEX_CLI_BINARY} login",
+            f"Guide: {installer_mod.CODEX_CLI_DOCS_URL}",
+        ]
+    if provider_key == "gemini":
+        return [
+            f"Install Node.js/npm if needed: https://nodejs.org/",
+            f"Install Gemini: {installer_mod.GEMINI_CLI_INSTALL_COMMAND}",
+            f"Sign in: {installer_mod.GEMINI_CLI_BINARY} login (or set GEMINI_API_KEY/Vertex)",
+            f"Guide: {installer_mod.GEMINI_CLI_DOCS_URL}",
+        ]
+    return [
+        f"Install Kimi: {installer_mod.KIMI_CLI_CURL_INSTALL_COMMAND}",
+        f"Or with uv: {installer_mod.KIMI_CLI_INSTALL_COMMAND}",
+        f"Sign in: {installer_mod.KIMI_CLI_BINARY} login",
+        f"Guide: {installer_mod.KIMI_CLI_DOCS_URL}",
+    ]
+
+
+def _offer_provider_dependency_installs(*, no_input: bool, stream: TextIO) -> None:
+    checks = [
+        ("codex", "Codex CLI", installer_mod._check_codex_cli()),
+        ("gemini", "Gemini CLI", installer_mod._check_gemini_cli()),
+        ("kimi", "Kimi CLI", installer_mod._check_kimi_cli()),
+    ]
+    missing = [(key, label) for key, label, check in checks if not check.found]
+    if not missing:
+        return
+
+    if no_input or not (sys.stdin.isatty() and sys.stdout.isatty()):
+        print(
+            "Skipping interactive dependency install because this terminal cannot answer questions; manual steps are shown below.",
+            file=stream,
+        )
+        return
+
+    for key, label in missing:
+        answer = _yes_default_prompt(
+            f"We need {label} for {key}-* teammates. Want me to try installing it for you?"
+        )
+        if answer is None:
+            print(f"Skipping {label} auto-install; manual steps will be shown below.", file=stream)
+            continue
+        if not answer:
+            print(f"Okay — I will not install {label}. Manual steps will be shown below.", file=stream)
+            continue
+        command = _provider_install_command(key)
+        if command is None:
+            print(f"I could not find the installer tool for {label}. Try this next:", file=stream)
+            for idx, step in enumerate(_manual_provider_steps(key), start=1):
+                print(f"  {idx}. {step}", file=stream)
+            continue
+        display, argv = command
+        print(f"Trying: {display}", file=stream)
+        ok, output = _run_install_command(argv)
+        if ok:
+            print(f"Installed {label}. You may still need to sign in before teammates can use it.", file=stream)
+        else:
+            print(f"I tried to install {label}, but it failed.", file=stream)
+            print("Raw installer output:", file=stream)
+            for line in output.splitlines() or ["No output captured."]:
+                print(f"  {line}", file=stream)
+            print("Try this next:", file=stream)
+            for idx, step in enumerate(_manual_provider_steps(key), start=1):
+                print(f"  {idx}. {step}", file=stream)
+            print("Still stuck? Report it:", file=stream)
+            print(f"  {_issue_url(title=f'{label} auto-install failed', raw_error=output)}", file=stream)
+
+
 def _install_command(
     *,
     settings_path: Path | str | None = None,
@@ -268,6 +446,8 @@ def _install_command(
     out: TextIO | None = None,
 ) -> int:
     stream = out or sys.stdout
+    if os.environ.get("CLAUDE_ANYTEAM_NPM_PARENT") != "1":
+        print(_version_banner(), file=stream)
     if assume_yes:
         prompt_fn = lambda _current: True
     elif no_input or self_heal:
@@ -277,6 +457,11 @@ def _install_command(
         prompt_fn = lambda _current: False
     else:
         prompt_fn = _interactive_prompt
+
+    _offer_provider_dependency_installs(
+        no_input=no_input or self_heal,
+        stream=stream,
+    )
 
     provider_status_rendered = False
 

--- a/src/claude_anyteam/cli.py
+++ b/src/claude_anyteam/cli.py
@@ -414,6 +414,11 @@ def _offer_provider_dependency_installs(*, no_input: bool, stream: TextIO) -> No
             print(f"I could not find the installer tool for {label}. Try this next:", file=stream)
             for idx, step in enumerate(_manual_provider_steps(key), start=1):
                 print(f"  {idx}. {step}", file=stream)
+            print("Still stuck? Report it:", file=stream)
+            print(
+                f"  {_issue_url(title=f'{label} installer tool missing', raw_error=f'No installer command found for {label}')}",
+                file=stream,
+            )
             continue
         display, argv = command
         print(f"Trying: {display}", file=stream)

--- a/src/claude_anyteam/installer.py
+++ b/src/claude_anyteam/installer.py
@@ -12,8 +12,10 @@ from __future__ import annotations
 import contextlib
 import copy
 import errno
+import importlib.metadata
 import json
 import os
+import platform as platform_mod
 import re
 import shutil
 import subprocess
@@ -23,6 +25,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Literal
+from urllib.parse import urlencode
 
 TEAMMATE_COMMAND_KEY = "CLAUDE_CODE_TEAMMATE_COMMAND"
 TEAMMATE_BINARY_KEY = "CLAUDE_ANYTEAM_BINARY"
@@ -84,6 +87,7 @@ INSTALL_ERROR_EXIT_GENERIC = 2
 INSTALL_ERROR_EXIT_PROMPT_DECLINED = 3
 INSTALL_ERROR_EXIT_CORRUPTED_STATE = 4
 INSTALL_ERROR_EXIT_NO_PROVIDER = 5
+ISSUE_NEW_URL = "https://github.com/JonathanRosado/claude-anyteam/issues/new"
 
 ProviderState = Literal["READY", "NEEDS_SIGNIN", "NEEDS_UPGRADE", "MISSING"]
 InstallSeverity = Literal["blocker", "hard-stop", "soft"]
@@ -337,19 +341,142 @@ class InstallError(ValueError):
             self.cli_exit_code = cli_exit_code  # type: ignore[attr-defined]
         super().__init__(self.as_plain_text())
 
-    def as_plain_text(self, *, include_details: bool = True) -> str:
+    def as_plain_text(self, *, include_details: bool = True, include_report: bool = True) -> str:
         lines = [
             self.title,
             self.explanation,
-            f"Next step: {self.action}",
+            "Try this next:",
+            *(f"  {index}. {line}" for index, line in enumerate(self.action.splitlines() or [self.action], start=1)),
             f"Severity: {self.severity}",
         ]
         if include_details and self.details:
             lines.extend(["Raw details:", self.details])
+        if include_report:
+            raw_error = self.as_plain_text(include_details=include_details, include_report=False)
+            lines.extend(
+                [
+                    "Still stuck? Report it:",
+                    f"  {build_issue_url(title=self.title, raw_error=raw_error)}",
+                ]
+            )
         return "\n".join(lines)
 
     def __str__(self) -> str:
         return self.as_plain_text()
+
+
+def installer_version() -> str:
+    env_version = os.environ.get("CLAUDE_ANYTEAM_NPM_VERSION")
+    if env_version:
+        return env_version
+    try:
+        return importlib.metadata.version("claude-anyteam")
+    except importlib.metadata.PackageNotFoundError:
+        pyproject = Path(__file__).resolve().parents[2] / "pyproject.toml"
+        try:
+            for line in pyproject.read_text(encoding="utf-8").splitlines():
+                if line.startswith("version = "):
+                    return line.split("=", 1)[1].strip().strip('"')
+        except OSError:
+            pass
+    return "unknown"
+
+
+def _tool_version(command: str) -> str:
+    try:
+        found = shutil.which(command)
+    except Exception as exc:
+        return f"version check skipped: {exc}"
+    if not found:
+        return "not found"
+    try:
+        completed = subprocess.run(
+            [found, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=3,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return f"found at {found}, but version check failed: {exc}"
+    return (completed.stdout or completed.stderr or "").strip() or f"found at {found}"
+
+
+def _os_label() -> str:
+    return f"{sys.platform} {platform_mod.release()} {platform_mod.machine()}"
+
+
+def _normalize_steps(
+    next_steps_per_os: dict[str, list[str] | tuple[str, ...] | str] | list[str] | tuple[str, ...] | str,
+) -> list[str]:
+    if isinstance(next_steps_per_os, str):
+        return [line for line in next_steps_per_os.splitlines() if line.strip()]
+    if isinstance(next_steps_per_os, (list, tuple)):
+        return [str(line) for line in next_steps_per_os if str(line).strip()]
+    if isinstance(next_steps_per_os, dict):
+        if _is_windows_platform() and "win32" in next_steps_per_os:
+            return _normalize_steps(next_steps_per_os["win32"])
+        if sys.platform == "darwin" and "darwin" in next_steps_per_os:
+            return _normalize_steps(next_steps_per_os["darwin"])
+        if sys.platform not in ("win32", "cygwin", "darwin") and "linux" in next_steps_per_os:
+            return _normalize_steps(next_steps_per_os["linux"])
+        return _normalize_steps(next_steps_per_os.get("default", []))
+    return []
+
+
+def build_issue_url(
+    *,
+    title: str,
+    raw_error: str,
+    what_doing: str = "I was running `claude-anyteam install`.",
+) -> str:
+    body = "\n".join(
+        [
+            "## What I was doing",
+            what_doing,
+            "",
+            "## Installer details",
+            f"- Installer version: {installer_version()}",
+            f"- OS: {_os_label()}",
+            f"- Python version: {sys.version.split()[0]}",
+            f"- uv version: {_tool_version('uv')}",
+            f"- Node version: {_tool_version('node')}",
+            "",
+            "## Raw error text",
+            "```text",
+            raw_error or "No raw error captured.",
+            "```",
+        ]
+    )
+    return f"{ISSUE_NEW_URL}?{urlencode({'title': f'[installer] {title[:120]}', 'body': body})}"
+
+
+def format_installer_diagnostic(
+    *,
+    summary: str,
+    raw_error: str,
+    next_steps_per_os: dict[str, list[str] | tuple[str, ...] | str] | list[str] | tuple[str, ...] | str,
+    title: str = "Installer error",
+    what_doing: str = "I was running `claude-anyteam install`.",
+    include_what_happened: bool = True,
+) -> list[str]:
+    steps = _normalize_steps(next_steps_per_os)
+    if not steps:
+        steps = [
+            "Read the message above.",
+            "Fix the problem it describes.",
+            "Run `claude-anyteam install` again.",
+        ]
+    lines: list[str] = []
+    if include_what_happened:
+        lines.append(f"What happened: {summary}")
+    lines.append("Try this next:")
+    lines.extend(f"  {index}. {step}" for index, step in enumerate(steps, start=1))
+    lines.append("Still stuck? Report it:")
+    lines.append(
+        f"  {build_issue_url(title=title, raw_error=raw_error, what_doing=what_doing)}"
+    )
+    return lines
 
 
 def _quote_command_path(path: Path) -> str:
@@ -555,8 +682,8 @@ def _provider_version_probe_error(
     return InstallError(
         title=f"Found `{binary}` but couldn't read its version",
         explanation=(
-            f"Found `{binary}` on PATH but it didn't return a recognizable version. "
-            "The installer will warn but continue — you may need to upgrade or reinstall the provider CLI."
+            f"Found `{binary}` on PATH (the command search list) but it didn't return a recognizable version. "
+            "The installer will warn but continue — you may need to upgrade or reinstall that provider app."
         ),
         action=f"Upgrade or reinstall {provider_name}, then run `{command}` again.",
         severity="soft",
@@ -661,9 +788,9 @@ def discover_managed_paths(
         raise InstallError(
             title="claude-anyteam is not on PATH",
             explanation=(
-                "The installer could not find the claude-anyteam command it needs to write into Claude Code settings."
+                "The installer could not find the claude-anyteam command on PATH (the list of folders your terminal searches for commands)."
             ),
-            action="Run `uv tool install --reinstall claude-anyteam`, then run `claude-anyteam install` again.",
+            action="Run `uv tool install --reinstall --prerelease=allow claude-anyteam`, then run `claude-anyteam install` again.",
             severity="blocker",
             details="Unable to resolve the claude-anyteam binary.",
         )
@@ -671,9 +798,9 @@ def discover_managed_paths(
         raise InstallError(
             title="claude-anyteam's spawn shim is not on PATH",
             explanation=(
-                "The installer could not find the spawn shim that Claude Code uses to launch routed teammates."
+                "The installer could not find the spawn shim (the small helper command Claude Code uses to launch routed teammates) on PATH."
             ),
-            action="Run `uv tool install --reinstall claude-anyteam`, then run `claude-anyteam install` again.",
+            action="Run `uv tool install --reinstall --prerelease=allow claude-anyteam`, then run `claude-anyteam install` again.",
             severity="blocker",
             details="Unable to resolve the claude-anyteam-spawn-shim binary.",
         )
@@ -2173,7 +2300,7 @@ def install(
 
     if not prereq.found:
         message = (
-            "claude-anyteam requires a terminal multiplexer on PATH; none was found.\n"
+            "claude-anyteam requires a terminal multiplexer called tmux (a tool that lets Claude Code show helper teammates in panes), and none was found on PATH.\n"
             "Install one of:\n"
             f"{_install_instructions(prereq.platform)}\n"
             "After installing, re-run `claude-anyteam install`."
@@ -2190,7 +2317,7 @@ def install(
         raise InstallError(
             title="A required terminal tool is missing",
             explanation=(
-                "claude-anyteam needs tmux on Linux/macOS so teammates can appear in Claude Code panes."
+                "claude-anyteam needs tmux on Linux/macOS. tmux is a terminal tool that lets teammates appear in Claude Code panes."
             ),
             action=f"Install tmux for your OS, then run `claude-anyteam install` again.\n{_install_instructions(prereq.platform)}",
             severity="blocker",
@@ -2674,9 +2801,10 @@ def _format_provider_status_table(
 def _format_no_provider_explainer() -> str:
     return "\n".join(
         [
-            "claude-anyteam routes some Claude Code teammates to external AI CLIs (Codex, Gemini, Kimi).",
-            "You need at least one signed-in CLI for it to do anything useful.",
-            "Pick whichever you have access to.",
+            "claude-anyteam lets Claude Code start helper teammates through provider apps: Codex, Gemini, or Kimi.",
+            "A provider app is a command-line app (a tool you run from Terminal or PowerShell).",
+            "You need at least one provider app installed and signed in before teammates can do useful work.",
+            "Pick whichever provider you have access to; you do not need all three.",
         ]
     )
 
@@ -2774,7 +2902,7 @@ def _format_no_provider_refusal_message() -> str:
     return (
         "Refusing to install — no provider is ready.\n"
         "  Follow the steps above, then re-run `claude-anyteam install`.\n\n"
-        "  Setting up later? Pass --force-empty to install with no provider ready:\n"
+        "  Want to set up the provider later? Pass --force-empty to install the wiring now:\n"
         "    claude-anyteam install --force-empty"
     )
 
@@ -2794,7 +2922,7 @@ def _format_provider_preamble(
         blocks.append(walkthrough)
     if force_empty and no_provider_ready:
         blocks.append(
-            "Proceeding with --force-empty: claude-anyteam is installed but inert until a CLI is ready."
+            "Proceeding with --force-empty: claude-anyteam is installed, but teammates will wait until a provider app is installed and signed in."
         )
     return "\n\n".join(blocks)
 
@@ -2814,14 +2942,25 @@ def _format_no_provider_ready_message(
 
 
 def _format_soft_diagnostic(diagnostic: InstallError) -> str:
-    return "\n".join(
-        [
-            f"Warning: {diagnostic.title}",
-            diagnostic.explanation,
-            f"Next step: {diagnostic.action}",
-            f"Severity: {diagnostic.severity}",
-        ]
+    raw_error = diagnostic.as_plain_text(include_details=True, include_report=False)
+    lines = [
+        f"Warning: {diagnostic.title}",
+        diagnostic.explanation,
+    ]
+    lines.extend(
+        format_installer_diagnostic(
+            summary=diagnostic.explanation,
+            raw_error=raw_error,
+            next_steps_per_os=diagnostic.action,
+            title=diagnostic.title,
+            include_what_happened=False,
+        )
     )
+    lines.append(f"Severity: {diagnostic.severity}")
+    if diagnostic.details:
+        lines.append("Raw details (for debugging):")
+        lines.extend(f"  {line}" for line in diagnostic.details.splitlines())
+    return "\n".join(lines)
 
 
 def format_install_message(result: InstallResult, *, include_provider_status: bool = True) -> str:

--- a/tests/test_error_translator.js
+++ b/tests/test_error_translator.js
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { test } from 'node:test';
-import { translate } from '../npm/lib/error-translator.js';
+import { buildIssueUrl, formatInstallerDiagnostic, translate } from '../npm/lib/error-translator.js';
 
 function assertTranslation(raw, context, expected) {
   const result = translate(raw, context);
@@ -43,7 +43,7 @@ test('uv-no-solution', () => {
       id: 'uv-no-solution',
       title: 'Python dependency conflict',
       severity: 'hard',
-      action: /uv tool install --reinstall claude-anyteam/,
+      action: /uv tool install --reinstall --prerelease=allow claude-anyteam/,
     },
   );
 });
@@ -337,4 +337,42 @@ test('fallback-unrecognized', () => {
   assert.equal(result.severity, 'hard');
   assert.match(result.action, /issues\/new/);
   assert.equal(result.raw, raw);
+});
+
+test('issue urls include cross-platform diagnosis fields', () => {
+  const url = new URL(buildIssueUrl({
+    title: 'Broken install',
+    installerVersion: '9.9.9',
+    os: 'win32 10.0.22631 x64',
+    pythonVersion: '3.12.2',
+    uvVersion: 'uv 0.5.0',
+    nodeVersion: 'v22.0.0',
+    rawError: 'raw boom',
+  }));
+  assert.equal(`${url.origin}${url.pathname}`, 'https://github.com/JonathanRosado/claude-anyteam/issues/new');
+  assert.match(url.searchParams.get('title'), /Broken install/);
+  const body = url.searchParams.get('body');
+  assert.match(body, /Installer version: 9\.9\.9/);
+  assert.match(body, /OS: win32 10\.0\.22631 x64/);
+  assert.match(body, /Python version: 3\.12\.2/);
+  assert.match(body, /uv version: uv 0\.5\.0/);
+  assert.match(body, /Node version: v22\.0\.0/);
+  assert.match(body, /raw boom/);
+});
+
+test('formatInstallerDiagnostic renders uniform next-step and report blocks', () => {
+  const lines = formatInstallerDiagnostic({
+    title: 'Missing thing',
+    summary: 'Thing is missing.',
+    rawError: 'thing missing',
+    nextStepsPerOs: {
+      win32: ['Open PowerShell as Administrator.', 'Run winget install Thing.'],
+      default: ['Run brew install thing.'],
+    },
+    os: 'win32 10 x64',
+    platform: 'win32',
+  });
+  assert.match(lines.join('\n'), /What happened: Thing is missing\./);
+  assert.match(lines.join('\n'), /Try this next:\n  1\. Open PowerShell as Administrator\.\n  2\. Run winget install Thing\./);
+  assert.match(lines.join('\n'), /Still stuck\? Report it:\n  https:\/\/github\.com\/JonathanRosado\/claude-anyteam\/issues\/new\?/);
 });

--- a/tests/test_install_command.py
+++ b/tests/test_install_command.py
@@ -2,8 +2,14 @@ from __future__ import annotations
 
 import errno
 import json
+import os
+import shutil
+import subprocess
+import textwrap
+from io import StringIO
 from pathlib import Path
 from typing import Any
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 
@@ -487,10 +493,119 @@ def test_install_command_renders_structured_install_error_box(monkeypatch, capsy
     assert "INSTALL FAILED" in err
     assert "Friendly title" in err
     assert "Plain English explanation." in err
-    assert "Next step: Run `fix-it`." in err
-    assert "Then retry." in err
+    assert "Try this next:" in err
+    assert "1. Run `fix-it`." in err
+    assert "2. Then retry." in err
     assert "Severity: blocker" in err
     assert "Raw details (for debugging):" in err
+    assert "Still stuck? Report it:" in err
+    assert "https://github.com/JonathanRosado/claude-anyteam/issues/new?" in err
+
+
+def test_python_version_banner_reads_npm_parent_version(monkeypatch):
+    monkeypatch.setenv("CLAUDE_ANYTEAM_NPM_VERSION", "9.9.9")
+    assert cli_mod._version_banner() == "claude-anyteam installer v9.9.9"
+
+
+def test_python_issue_url_includes_runtime_diagnostics(monkeypatch):
+    monkeypatch.setenv("CLAUDE_ANYTEAM_NPM_VERSION", "9.9.9")
+    url = installer_mod.build_issue_url(title="Broken install", raw_error="raw boom")
+    parsed = urlparse(url)
+    assert parsed.scheme == "https"
+    assert parsed.netloc == "github.com"
+    assert parsed.path == "/JonathanRosado/claude-anyteam/issues/new"
+    query = parse_qs(parsed.query)
+    assert "Broken install" in query["title"][0]
+    body = query["body"][0]
+    assert "Installer version: 9.9.9" in body
+    assert "OS:" in body
+    assert "Python version:" in body
+    assert "uv version:" in body
+    assert "Node version:" in body
+    assert "raw boom" in body
+
+
+def test_dependency_installer_skips_cleanly_without_tty(monkeypatch):
+    monkeypatch.setattr(installer_mod, "_check_codex_cli", lambda: _codex_cli_missing())
+    monkeypatch.setattr(installer_mod, "_check_gemini_cli", lambda: _gemini_cli_missing())
+    monkeypatch.setattr(installer_mod, "_check_kimi_cli", lambda: _kimi_cli_missing())
+
+    stream = StringIO()
+    cli_mod._offer_provider_dependency_installs(no_input=True, stream=stream)
+
+    assert "Skipping interactive dependency install" in stream.getvalue()
+
+
+def test_npm_uv_tool_invocations_allow_prerelease_dependencies(tmp_path: Path):
+    """Regression for fastmcp==3.0.0b1: every claude-anyteam uv tool resolve
+    must opt into pre-releases so clean machines do not hit uv's resolver hint.
+    """
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("node is required for npm installer regression test")
+
+    root = Path(__file__).resolve().parents[1]
+    log_path = tmp_path / "uv-args.jsonl"
+    bin_dir = tmp_path / "uv-bin"
+    fake_uv = tmp_path / "uv"
+    fake_uv.write_text(
+        textwrap.dedent(
+            f"""\
+            #!/usr/bin/env python3
+            import json, os, pathlib, sys
+            args = sys.argv[1:]
+            with open({str(log_path)!r}, "a", encoding="utf-8") as handle:
+                handle.write(json.dumps(args) + "\\n")
+            if args == ["--no-config", "tool", "dir", "--bin"]:
+                print(os.environ["TEST_UV_BIN_DIR"])
+                raise SystemExit(0)
+            if args[:3] == ["--no-config", "tool", "install"]:
+                bindir = pathlib.Path(os.environ["TEST_UV_BIN_DIR"])
+                bindir.mkdir(parents=True, exist_ok=True)
+                for name in ("claude-anyteam", "claude-anyteam-spawn-shim"):
+                    target = bindir / name
+                    target.write_text("#!/bin/sh\\nexit 0\\n", encoding="utf-8")
+                    target.chmod(0o755)
+                raise SystemExit(0)
+            raise SystemExit(0)
+            """
+        ),
+        encoding="utf-8",
+    )
+    fake_uv.chmod(0o755)
+
+    script = textwrap.dedent(
+        f"""\
+        import {{ installTool }} from {str(root / 'npm' / 'lib' / 'detect.js')!r};
+        await installTool({{ uvPath: {str(fake_uv)!r}, pythonPath: {str(Path('/usr/bin/python3'))!r} }});
+        """
+    )
+    env = {
+        **os.environ,
+        "TEST_UV_BIN_DIR": str(bin_dir),
+        "CLAUDE_ANYTEAM_UV_TOOL_BIN_DIR": str(bin_dir),
+    }
+    completed = subprocess.run(
+        [node, "--input-type=module", "-e", script],
+        cwd=root,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+    assert completed.returncode == 0, completed.stderr
+
+    argv_lines = [
+        json.loads(line)
+        for line in log_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    install_argv = next(args for args in argv_lines if args[:3] == ["--no-config", "tool", "install"])
+    assert "--prerelease=allow" in install_argv
+
+    setup_source = (root / "npm" / "bin" / "setup.js").read_text(encoding="utf-8")
+    assert "'tool',\n    'run',\n    '--prerelease=allow'," in setup_source
 
 
 # ---------------------------------------------------------------------------
@@ -914,7 +1029,7 @@ def test_install_force_empty_with_no_providers_updates_settings(
 
     stdout = capsys.readouterr().out
     assert (
-        "Proceeding with --force-empty: claude-anyteam is installed but inert until a CLI is ready."
+        "Proceeding with --force-empty: claude-anyteam is installed, but teammates will wait until a provider app is installed and signed in."
         in stdout
     )
     assert "Refusing to install" not in stdout

--- a/tests/test_npm_package.py
+++ b/tests/test_npm_package.py
@@ -79,6 +79,9 @@ def test_setup_delegates_to_python_installer() -> None:
     assert "'--assume-yes'" in setup_source, (
         'setup.js must always pass --assume-yes since npx is non-interactive'
     )
+    assert "'--prerelease=allow'" in setup_source, (
+        'setup.js must allow pre-release Python deps when uv resolves claude-anyteam'
+    )
     # stdio must be inherited so the Python installer's messages reach the user.
     assert "stdio:" in setup_source and "'inherit'" in setup_source
 
@@ -87,6 +90,13 @@ def test_setup_delegates_to_python_installer() -> None:
     assert "from '../lib/settings.js'" not in setup_source
     assert 'TEAMMATE_COMMAND_KEY' not in setup_source
     assert 'TEAMMATE_BINARY_KEY' not in setup_source
+
+
+def test_npm_version_banner_reads_package_json() -> None:
+    setup_source = (NPM_DIR / 'bin' / 'setup.js').read_text(encoding='utf-8')
+
+    assert "readFileSync(new URL('../package.json', import.meta.url)" in setup_source
+    assert 'claude-anyteam installer v${INSTALLER_VERSION}' in setup_source
 
 
 def test_setup_refreshes_plugin_on_every_run() -> None:


### PR DESCRIPTION
## Why

`npx --yes claude-anyteam` was failing on fresh hosts (Windows reproducer below) and leaving users alone with raw uv resolver output. Per the user brief: "our users may be 12-year-olds, and so they need a ton of handholding."

Original failure (real user report):

```
✔ Python 3 detected (3.14.3) C:\Python314\python.exe
✔ uv ready uv 0.11.1 ... C:\Users\rosad\.local\bin\uv.exe
✔ existing claude-anyteam tool detected ...

● Running claude-anyteam install (Python) ...
  x No solution found when resolving tool dependencies:
  `-> Because there is no version of fastmcp==3.0.0b1 and all
      versions of claude-anyteam depend on fastmcp==3.0.0b1, we can
      conclude that all versions of claude-anyteam cannot be used.

      hint: `fastmcp` was requested with a pre-release marker
      (e.g., fastmcp==3.0.0b1), but pre-releases weren't enabled
      (try: `--prerelease=allow`)
```

That experience is fixed and made unrepeatable.

## What changed (user-facing)

- **Small version banner.** `claude-anyteam installer v0.6.1` printed once near the top, sourced from `npm/package.json`. Suppressed in the Python child when invoked from the npm wrapper (`CLAUDE_ANYTEAM_NPM_PARENT=1`) so the version isn't printed twice.
- **fastmcp pre-release fix.** `--prerelease=allow` is now passed to every `uv tool install` / `uv tool run` invocation across the npm wrapper AND the Python installer, AND to every user-facing recovery command the installer prints. Locked in by regression tests on both sides.
- **Interactive "install missing dep?" prompts.** When a dependency is missing, the installer asks before attempting (default Yes on Enter). Cross-platform install chain: `winget → scoop → choco` on Windows, `brew` on macOS, `apt-get → dnf → pacman → apk` on Linux. Skipped cleanly with a clear "non-interactive — see manual instructions" message when stdin is piped or in CI.
- **Every error path now ends with two blocks.** "Try this next" with ordered recovery steps, and "Still stuck? Report it" with a **prefilled** GitHub issue link. The issue body carries installer version, OS + arch + release, Python/uv/Node versions, raw error text, and a "What I was doing" placeholder — so reports are self-describing across Windows, macOS, and Linux.
- **Beautiful, narrow-terminal-safe display.** Box width clamped to `min(stdout.columns - 4, 96)` (floor 40) so the prefilled URL doesn't blow boxes out to ~1500 columns wide. Long lines word-wrap; URLs hard-break at the budget. Big ASCII banner at ≥82 cols, short `claude-anyteam` fallback below that. Friendly, jargon-free copy throughout (12-year-old reading level — explanations inline where any term might confuse a beginner).

## Tests

- `tests/test_install_command.py` — 65+ tests including new regression for `--prerelease=allow` in argv across both subprocess invocation and the user-facing recovery text.
- `tests/test_npm_package.py` — asserts the flag is present in the npm wrapper source.
- `tests/test_error_translator.js` — 26 Node tests covering 24 known error fixtures (uv-prerelease-blocked, uv-no-solution-conflict, conda-interference, windows-antivirus-quarantine, …) + the cross-platform `buildIssueUrl` helper + `formatInstallerDiagnostic` block formatting.

All green: 129 pytest, 26 node `--test`.

## Manual scenarios verified

- Happy path on Linux with full deps — clean output, version banner, full ASCII banner, green checks.
- Missing uv with non-TTY stdin — yellow "skipping auto-install" box explains why, then red "uv not installed" box with manual install steps + prefilled issue link.
- Narrow terminal `COLUMNS=40` — banner degrades to short form, boxes clamp to 40 cols, lines wrap inside.
- Wide terminal `COLUMNS=100` — full banner, 96-col boxes, URL wraps at the budget.

## Commits

- `6a83533` installer: handholding UX, prefilled issue links, fastmcp pre-release fix
- `7127366` installer: clamp box width and wrap long lines so prefilled URLs don't blow out the terminal
- `e03c8d6` installer(cli): add issue link to provider-tool-missing error path

🤖 Generated with [Claude Code](https://claude.com/claude-code)