### PR TITLE
v0.7.1 — installer: always refresh cached tool, prompt before tmux failure

### DIFF
--- a/npm/bin/setup.js
+++ b/npm/bin/setup.js
@@ -628,15 +628,30 @@ async function main() {
 
   let tool;
   const existingTool = await findInstalledTool({ uvPath: uv.path }).catch(() => null);
-  if (existingTool) {
-    tool = existingTool;
+  // Always run `uv tool install --force --prerelease=allow` so a cached older
+  // claude-anyteam binary gets refreshed to the latest published wheel. Without
+  // this, a user who installed at v0.5.x and re-runs `npx --yes claude-anyteam`
+  // never sees handholding/prompt logic shipped in later releases.
+  const installLabel = existingTool ? 'Refreshing' : 'Installing';
+  try {
+    tool = await withSpinner(`${installLabel} ${TOOL_NAME} with uv tool install`, !silent, () => installTool({ uvPath: uv.path, pythonPath: python.path, refresh: true }));
     if (!silent) {
-      console.log(`${theme.symbols.success} ${theme.heading('existing claude-anyteam tool detected')} ${theme.accent(formatDisplayPath(tool.binaryPath))}`);
+      const status = tool.installMode === 'refreshed' ? 'refreshed to latest' : 'installed';
+      console.log(`${theme.symbols.success} ${theme.heading(`claude-anyteam tool ${status}`)} ${theme.accent(formatDisplayPath(tool.binaryPath))}`);
     }
-  } else {
-    try {
-      tool = await withSpinner(`Installing ${TOOL_NAME} with uv tool install`, !silent, () => installTool({ uvPath: uv.path, pythonPath: python.path }));
-    } catch (error) {
+  } catch (error) {
+    if (existingTool) {
+      // Refresh failed but we still have a working older copy — degrade
+      // gracefully rather than blocking on a transient registry error.
+      tool = existingTool;
+      if (!silent) {
+        console.log(`${theme.symbols.warn} ${theme.heading('Could not refresh claude-anyteam')} ${theme.muted('— continuing with existing copy')} ${theme.accent(formatDisplayPath(tool.binaryPath))}`);
+        const refreshDetail = (error.details || error.message || '').split(/\r?\n/, 1)[0];
+        if (refreshDetail) {
+          console.log(`${theme.symbols.info} ${theme.muted(`Refresh error: ${refreshDetail}`)}`);
+        }
+      }
+    } else {
       if (silent) {
         postinstallHint(error);
         return 0;

--- a/npm/lib/detect.js
+++ b/npm/lib/detect.js
@@ -492,10 +492,12 @@ export async function findInstalledTool({ uvPath }) {
   return null;
 }
 
-export async function installTool({ uvPath, pythonPath }) {
-  const existing = await findInstalledTool({ uvPath }).catch(() => null);
-  if (existing) {
-    return existing;
+export async function installTool({ uvPath, pythonPath, refresh = false }) {
+  if (!refresh) {
+    const existing = await findInstalledTool({ uvPath }).catch(() => null);
+    if (existing) {
+      return existing;
+    }
   }
 
   const { env, binDir } = await resolveToolBinDir({ uvPath });
@@ -534,7 +536,7 @@ export async function installTool({ uvPath, pythonPath }) {
     error.details = `uv reported bin directory ${binDir}, but neither the claude-anyteam nor legacy codex-teammate binaries were available.`;
     throw error;
   }
-  return { env, binDir, ...resolvedPaths, installMode: 'installed' };
+  return { env, binDir, ...resolvedPaths, installMode: refresh ? 'refreshed' : 'installed' };
 }
 
 export async function ensureWindowsLongPaths() {

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-anyteam",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Beautiful zero-friction installer for claude-anyteam in Claude Code.",
   "type": "module",
   "bin": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "claude-anyteam"
-version = "0.7.0"
+version = "0.7.1"
 description = "Bring Codex, Gemini, and Kimi CLI powered teammates into Claude Code with multi-backend routing."
 requires-python = ">=3.12"
 license = "MIT"

--- a/src/claude_anyteam/cli.py
+++ b/src/claude_anyteam/cli.py
@@ -382,6 +382,65 @@ def _manual_provider_steps(provider_key: str) -> list[str]:
     ]
 
 
+def _multiplexer_install_command() -> tuple[str, list[str]] | None:
+    if sys.platform == "darwin":
+        brew = shutil.which("brew")
+        if brew:
+            return "brew install tmux", [brew, "install", "tmux"]
+        return None
+    if sys.platform.startswith("linux"):
+        for pm, install_args in (
+            ("apt-get", ["sudo", "apt-get", "install", "-y", "tmux"]),
+            ("dnf", ["sudo", "dnf", "install", "-y", "tmux"]),
+            ("pacman", ["sudo", "pacman", "-S", "--noconfirm", "tmux"]),
+            ("apk", ["sudo", "apk", "add", "tmux"]),
+        ):
+            if shutil.which(pm):
+                return " ".join(install_args), install_args
+    return None
+
+
+def _offer_multiplexer_install(*, no_input: bool, stream: TextIO) -> None:
+    """Prompt the user to install tmux when missing on Linux/macOS.
+
+    Runs before install_settings()'s prereq check so a successful auto-install
+    means the subsequent check finds tmux on PATH and the install proceeds
+    without raising. Failure or decline falls through to the existing
+    InstallError, which already prints platform-aware manual instructions.
+    """
+    check = installer_mod._check_terminal_multiplexer()
+    if check.found:
+        return
+    if no_input or not (sys.stdin.isatty() and sys.stdout.isatty()):
+        # Stay silent here; the InstallError later will print full instructions.
+        return
+    answer = _yes_default_prompt(
+        "We need tmux (a terminal multiplexer that lets teammates appear in their own panes). "
+        "Want me to try installing it for you?"
+    )
+    if answer is None or not answer:
+        if answer is False:
+            print("Okay — I will not install tmux. Manual steps will be shown below.", file=stream)
+        return
+    command = _multiplexer_install_command()
+    if command is None:
+        print("I could not find a package manager (brew/apt-get/dnf/pacman/apk) to install tmux automatically.", file=stream)
+        return
+    display, argv = command
+    print(f"Trying: {display}", file=stream)
+    if argv and argv[0] == "sudo":
+        print("(You may be prompted for your sudo password.)", file=stream)
+    ok, output = _run_install_command(argv)
+    if ok:
+        print("Installed tmux. Continuing with claude-anyteam setup.", file=stream)
+        return
+    print("I tried to install tmux, but it failed.", file=stream)
+    print("Raw installer output:", file=stream)
+    for line in output.splitlines() or ["No output captured."]:
+        print(f"  {line}", file=stream)
+    print("Falling through to manual instructions below.", file=stream)
+
+
 def _offer_provider_dependency_installs(*, no_input: bool, stream: TextIO) -> None:
     checks = [
         ("codex", "Codex CLI", installer_mod._check_codex_cli()),
@@ -463,6 +522,10 @@ def _install_command(
     else:
         prompt_fn = _interactive_prompt
 
+    # --assume-yes is the npm wrapper's "approve settings.json modifications"
+    # signal, NOT a "skip every chance to ask the user about installing a
+    # missing dep" signal. TTY detection inside the helpers gates the prompts.
+    _offer_multiplexer_install(no_input=no_input or self_heal, stream=stream)
     _offer_provider_dependency_installs(
         no_input=no_input or self_heal,
         stream=stream,

--- a/tests/test_npm_package.py
+++ b/tests/test_npm_package.py
@@ -12,7 +12,7 @@ def test_npm_package_metadata_matches_installer_contract() -> None:
     package = json.loads((NPM_DIR / 'package.json').read_text(encoding='utf-8'))
 
     assert package['name'] == 'claude-anyteam'
-    assert package['version'] == '0.7.0'
+    assert package['version'] == '0.7.1'
     assert package['bin']['claude-anyteam-setup'] == 'bin/setup.js'
     assert package['bin']['claude-anyteam'] == 'bin/setup.js'
     assert package['scripts']['postinstall'] == 'node bin/setup.js --postinstall'

--- a/uv.lock
+++ b/uv.lock
@@ -132,7 +132,7 @@ wheels = [
 
 [[package]]
 name = "claude-anyteam"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Why

Two gaps in v0.7.0 kept the new handholding/prompt flows from reaching real users:

1. **npm wrapper reused the cached claude-anyteam binary as-is.** A user who first installed at v0.5.x and later ran \`npx --yes claude-anyteam\` was still served the old Python tool — they never executed any of the new prompt logic shipped in v0.7.0. Hit by user testing on Windows: their \`C:\\Users\\rosad\\AppData\\Local\\claude-anyteam\\bin\\claude-anyteam.exe\` was a pre-v0.7.0 copy and produced the pre-v0.7.0 \"requires a terminal multiplexer on PATH; none was found\" / \"winget install psmux\" message — text that doesn't even exist in main anymore.

2. **The terminal-multiplexer-missing path raised \`InstallError\` without asking.** On Linux/macOS where tmux IS detected, the installer just dumps install commands and exits non-zero. No \"want me to try installing it for you?\" prompt — even though \`_offer_provider_dependency_installs\` next to it does exactly that for the Codex/Gemini/Kimi CLIs.

## Changes

- **npm wrapper always refreshes.** \`installTool()\` takes \`refresh: true\` to bypass the early-return-on-existing branch; setup.js always runs \`uv tool install --force --prerelease=allow\` so every \`npx --yes\` picks up the latest wheel. On refresh failure when an existing copy is present, degrade to the cached binary with a warn line rather than blocking.
- **Multiplexer prompt+install.** New \`_offer_multiplexer_install\` runs before \`install_settings()\`: TTY-gated, prompts to install tmux, attempts \`brew install tmux\` on macOS or \`sudo apt-get/dnf/pacman/apk\` on Linux, falls through to the existing platform-aware \`InstallError\` on decline/failure. Same shape as \`_offer_provider_dependency_installs\`.

## Tests

- 129 pytest pass
- 26 Node tests pass
- Sandboxed \`node npm/bin/setup.js\` with empty PATH produces clean v0.7.1 banner + clamped error block + prefilled GitHub issue link.

## Commits

- \`34fef93\` v0.7.1 — installer: always refresh cached tool, prompt before tmux failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)