### PR TITLE
v0.7.2 — beautify Python installer output, fix kimi PATH detection, auto-release on merge

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,90 @@
+name: Auto-tag and release on version bump
+
+# When a push to main changes the version in npm/package.json, this workflow:
+#   1. Verifies the version is consistent with pyproject.toml
+#   2. Creates a v$VERSION tag at the new commit
+#   3. Creates a GitHub release on that tag
+# Pushing the tag triggers .github/workflows/release.yml, which runs tests
+# and publishes to npm + PyPI. This means a merge to main is the only
+# manual step needed to ship a new version — no separate `gh release create`.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'npm/package.json'
+      - 'pyproject.toml'
+
+concurrency:
+  group: auto-release
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  maybe-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Read manifest versions
+        id: ver
+        run: |
+          set -euo pipefail
+          npm_version=$(node -p "require('./npm/package.json').version")
+          py_version=$(awk -F\" '/^version *= */ {print $2; exit}' pyproject.toml)
+          echo "npm=$npm_version" >> "$GITHUB_OUTPUT"
+          echo "py=$py_version" >> "$GITHUB_OUTPUT"
+          if [ "$npm_version" != "$py_version" ]; then
+            echo "::error::npm/package.json version ($npm_version) does not match pyproject.toml ($py_version). Bump both in lock-step."
+            exit 1
+          fi
+          echo "version=$npm_version" >> "$GITHUB_OUTPUT"
+          echo "Resolved version: $npm_version"
+
+      - name: Skip if v$VERSION tag already exists
+        id: check_tag
+        run: |
+          set -euo pipefail
+          tag="v${{ steps.ver.outputs.version }}"
+          if git rev-parse "$tag" >/dev/null 2>&1; then
+            echo "Tag $tag already exists; nothing to do."
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create release notes from PR body
+        if: steps.check_tag.outputs.exists == 'false'
+        id: notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          pr_number=$(gh pr list --state merged --base main --search "${{ github.sha }}" --json number --jq '.[0].number // empty')
+          if [ -n "$pr_number" ]; then
+            gh pr view "$pr_number" --json body --jq '.body' > pr_body.md
+            echo "source=PR #$pr_number" >> "$GITHUB_OUTPUT"
+          else
+            git log -1 --format='%B' "${{ github.sha }}" > pr_body.md
+            echo "source=commit ${{ github.sha }}" >> "$GITHUB_OUTPUT"
+          fi
+          echo "notes_path=pr_body.md" >> "$GITHUB_OUTPUT"
+
+      - name: Create tag and release
+        if: steps.check_tag.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          tag="v${{ steps.ver.outputs.version }}"
+          title="$tag"
+          gh release create "$tag" \
+            --target "${{ github.sha }}" \
+            --title "$title" \
+            --notes-file "${{ steps.notes.outputs.notes_path }}"
+          echo "Released $tag (notes from ${{ steps.notes.outputs.source }})."

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-anyteam",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Beautiful zero-friction installer for claude-anyteam in Claude Code.",
   "type": "module",
   "bin": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "claude-anyteam"
-version = "0.7.1"
+version = "0.7.2"
 description = "Bring Codex, Gemini, and Kimi CLI powered teammates into Claude Code with multi-backend routing."
 requires-python = ">=3.12"
 license = "MIT"

--- a/src/claude_anyteam/_theme.py
+++ b/src/claude_anyteam/_theme.py
@@ -1,0 +1,221 @@
+"""ANSI theme + box renderer for the Python installer's user-facing output.
+
+Mirrors npm/lib/art.js so visual style is consistent across the npm wrapper
+and the Python child it spawns. Pure stdlib — no new dependencies. Honors
+LC_ALL=C / cmd-codepage with an ASCII glyph + border fallback.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from typing import Iterable
+
+_ANSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+
+
+def _supports_unicode(env: dict | None = None, platform: str | None = None) -> bool:
+    env = env if env is not None else os.environ
+    if env.get("CLAUDE_ANYTEAM_ASCII") == "1" or env.get("CLAUDE_ANYTEAM_FORCE_ASCII") == "1":
+        return False
+    if env.get("CLAUDE_ANYTEAM_UNICODE") == "1" or env.get("CLAUDE_ANYTEAM_FORCE_UNICODE") == "1":
+        return True
+    locale = env.get("LC_ALL") or env.get("LC_CTYPE") or env.get("LANG") or ""
+    if re.fullmatch(r"(?i)C|POSIX", locale):
+        return False
+    if re.search(r"(?i)UTF-?8", locale):
+        return True
+    plat = platform if platform is not None else sys.platform
+    if plat == "win32":
+        return bool(env.get("WT_SESSION") or env.get("TERM_PROGRAM") or env.get("ConEmuANSI") == "ON" or env.get("ANSICON"))
+    return bool(locale)
+
+
+def _supports_color(stream=None) -> bool:
+    if os.environ.get("NO_COLOR"):
+        return False
+    if os.environ.get("FORCE_COLOR"):
+        return True
+    target = stream if stream is not None else sys.stdout
+    isatty = getattr(target, "isatty", lambda: False)()
+    if not isatty:
+        return False
+    if sys.platform == "win32":
+        # Modern Windows Terminal / VS Code terminal support ANSI;
+        # legacy cmd.exe needs an explicit enable. Try the SetConsoleMode call.
+        try:
+            import ctypes
+            kernel32 = ctypes.windll.kernel32
+            handle = kernel32.GetStdHandle(-11)
+            mode = ctypes.c_ulong()
+            if kernel32.GetConsoleMode(handle, ctypes.byref(mode)):
+                kernel32.SetConsoleMode(handle, mode.value | 0x0004)  # ENABLE_VIRTUAL_TERMINAL_PROCESSING
+        except Exception:  # pragma: no cover - best-effort enable
+            pass
+        return bool(os.environ.get("WT_SESSION") or os.environ.get("TERM_PROGRAM") or os.environ.get("ConEmuANSI") == "ON" or os.environ.get("ANSICON")) or True
+    return True
+
+
+def strip_ansi(value: str) -> str:
+    return _ANSI_RE.sub("", str(value or ""))
+
+
+_FG = {
+    "black": 30, "red": 31, "green": 32, "yellow": 33,
+    "blue": 34, "magenta": 35, "cyan": 36, "white": 37,
+    "gray": 90, "bright_red": 91, "bright_green": 92, "bright_yellow": 93,
+    "bright_blue": 94, "bright_magenta": 95, "bright_cyan": 96, "bright_white": 97,
+}
+
+
+class Theme:
+    def __init__(self, color: bool, unicode: bool) -> None:
+        self.color = color
+        self.unicode = unicode
+        self._symbols_unicode = {"success": "✔", "info": "●", "warn": "▲", "error": "✖", "bullet": "•", "arrow": "→"}
+        self._symbols_ascii = {"success": "[OK]", "info": "[i]", "warn": "[!]", "error": "[X]", "bullet": "*", "arrow": "->"}
+
+    def _wrap(self, value: str, code: int, *, bold: bool = False) -> str:
+        if not self.color:
+            return value
+        prefix = "\x1b[1m" if bold else ""
+        suffix = "\x1b[22m" if bold else ""
+        return f"{prefix}\x1b[{code}m{value}\x1b[39m{suffix}"
+
+    def fg(self, value: str, color: str, *, bold: bool = False) -> str:
+        return self._wrap(value, _FG.get(color, 39), bold=bold)
+
+    def heading(self, value: str) -> str:
+        return self.fg(value, "white", bold=True)
+
+    def accent(self, value: str) -> str:
+        return self.fg(value, "cyan", bold=True)
+
+    def success(self, value: str) -> str:
+        return self.fg(value, "green", bold=True)
+
+    def warn(self, value: str) -> str:
+        return self.fg(value, "yellow", bold=True)
+
+    def danger(self, value: str) -> str:
+        return self.fg(value, "red", bold=True)
+
+    def muted(self, value: str) -> str:
+        return self.fg(value, "gray")
+
+    @property
+    def symbols(self) -> dict[str, str]:
+        base = self._symbols_unicode if self.unicode else self._symbols_ascii
+        if not self.color:
+            return base
+        return {
+            "success": self.fg(base["success"], "green"),
+            "info": self.fg(base["info"], "cyan"),
+            "warn": self.fg(base["warn"], "yellow"),
+            "error": self.fg(base["error"], "red"),
+            "bullet": self.fg(base["bullet"], "gray"),
+            "arrow": self.fg(base["arrow"], "cyan"),
+        }
+
+
+def get_theme(stream=None) -> Theme:
+    return Theme(color=_supports_color(stream), unicode=_supports_unicode())
+
+
+_BORDER_PALETTE = {"cyan": 36, "green": 32, "red": 31, "yellow": 33, "magenta": 35, "blue": 34, "gray": 90}
+_BOX_MAX_WIDTH = 96
+_BOX_MIN_WIDTH = 40
+
+
+def _terminal_columns() -> int:
+    cols_env = os.environ.get("COLUMNS")
+    if cols_env and cols_env.isdigit():
+        return int(cols_env)
+    try:
+        return os.get_terminal_size().columns
+    except OSError:
+        return 80
+
+
+def _wrap_visible(row: str, width: int) -> list[str]:
+    """Word-wrap a single row to at most width visible columns, preserving ANSI."""
+    if len(strip_ansi(row)) <= width:
+        return [row]
+    tokens = re.split(r"(\s+)", row)
+    lines: list[str] = []
+    current = ""
+    current_visible = 0
+
+    def _flush() -> None:
+        nonlocal current, current_visible
+        if current:
+            lines.append(current)
+        current = ""
+        current_visible = 0
+
+    for tok in tokens:
+        tok_visible = len(strip_ansi(tok))
+        if tok_visible == 0:
+            continue
+        if tok_visible > width:
+            _flush()
+            remaining = tok
+            while len(strip_ansi(remaining)) > width:
+                cut, visible = 0, 0
+                for ch in remaining:
+                    if visible >= width:
+                        break
+                    cut += len(ch)
+                    visible += 1
+                lines.append(remaining[:cut])
+                remaining = remaining[cut:]
+            if strip_ansi(remaining):
+                current = remaining
+                current_visible = len(strip_ansi(remaining))
+            continue
+        if current_visible + tok_visible > width:
+            _flush()
+            if tok.isspace():
+                continue
+        current += tok
+        current_visible += tok_visible
+    _flush()
+    return lines or [row]
+
+
+def render_box(title: str, lines: Iterable[str], color: str = "cyan", *, theme: Theme | None = None) -> str:
+    theme = theme or get_theme()
+    code = _BORDER_PALETTE.get(color, 36)
+    paint = (lambda v: f"\x1b[{code}m{v}\x1b[39m") if theme.color else (lambda v: v)
+    if theme.unicode:
+        b = {"tl": "╭", "tr": "╮", "ml": "├", "mr": "┤", "bl": "╰", "br": "╯", "h": "─", "v": "│"}
+    else:
+        b = {"tl": "+", "tr": "+", "ml": "+", "mr": "+", "bl": "+", "br": "+", "h": "-", "v": "|"}
+
+    cols = _terminal_columns()
+    budget = max(_BOX_MIN_WIDTH, min(_BOX_MAX_WIDTH, cols - 4))
+    body_rows = [r for line in lines for r in str(line).split("\n") for r in _wrap_visible(r, budget)]
+    title_rows = _wrap_visible(str(title), budget)
+    rows = [*title_rows, *body_rows]
+    width = max((len(strip_ansi(r)) for r in rows), default=0)
+
+    def _fill(row: str) -> str:
+        return f"{row}{' ' * (width - len(strip_ansi(row)))}"
+
+    return "\n".join(
+        [
+            paint(f"{b['tl']}{b['h'] * (width + 2)}{b['tr']}"),
+            *(f"{paint(b['v'])} {_fill(r)} {paint(b['v'])}" for r in title_rows),
+            paint(f"{b['ml']}{b['h'] * (width + 2)}{b['mr']}"),
+            *(f"{paint(b['v'])} {_fill(r)} {paint(b['v'])}" for r in body_rows),
+            paint(f"{b['bl']}{b['h'] * (width + 2)}{b['br']}"),
+        ]
+    )
+
+
+def section_header(theme: Theme, title: str, detail: str | None = None) -> str:
+    head = f"{theme.symbols['info']} {theme.accent(title)}"
+    if detail:
+        head = f"{head} {theme.muted(detail)}"
+    return head

--- a/src/claude_anyteam/cli.py
+++ b/src/claude_anyteam/cli.py
@@ -19,6 +19,7 @@ from typing import TextIO
 from urllib.parse import urlencode
 
 from . import logger
+from ._theme import get_theme, render_box
 from .config import from_env
 from claude_anyteam import installer as installer_mod
 from claude_anyteam.installer import (
@@ -315,11 +316,46 @@ def _interactive_prompt(current_value: str) -> bool:
 def _yes_default_prompt(question: str) -> bool | None:
     if not (sys.stdin.isatty() and sys.stdout.isatty()):
         return None
+    theme = get_theme()
+    prompt = f"{theme.symbols['info']} {theme.heading(question)} {theme.muted('[Y/n]')} "
     try:
-        answer = input(f"{question} [Y/n] ")
+        answer = input(prompt)
     except EOFError:
         return None
     return answer.strip().lower() not in {"n", "no"}
+
+
+def _refresh_path_for_uv_tools() -> None:
+    """After `uv tool install`, the new binary lives in `uv tool dir --bin`.
+
+    On Windows that's typically %APPDATA%\\Local\\uv\\tools\\bin, which may not
+    be on the calling shell's PATH. Without this refresh, subsequent
+    shutil.which() probes for the freshly-installed CLI return None and the
+    provider-status table reports it as missing — even though the install
+    succeeded. Prepend the uv tool bin dir to os.environ["PATH"] so checks
+    later in the same Python process can find the binary.
+    """
+    uv = shutil.which("uv")
+    if not uv:
+        return
+    try:
+        completed = subprocess.run(
+            [uv, "tool", "dir", "--bin"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return
+    bin_dir = (completed.stdout or "").strip().splitlines()[-1] if completed.stdout else ""
+    if not bin_dir or not os.path.isdir(bin_dir):
+        return
+    current = os.environ.get("PATH", "")
+    parts = current.split(os.pathsep) if current else []
+    if bin_dir in parts:
+        return
+    os.environ["PATH"] = bin_dir + os.pathsep + current
 
 
 def _run_install_command(args: list[str], *, timeout_s: int = 300) -> tuple[bool, str]:
@@ -336,7 +372,12 @@ def _run_install_command(args: list[str], *, timeout_s: int = 300) -> tuple[bool
     output = "\n".join(
         part for part in ((completed.stdout or "").strip(), (completed.stderr or "").strip()) if part
     )
-    return completed.returncode == 0, output or f"exit code {completed.returncode}"
+    ok = completed.returncode == 0
+    if ok and len(args) >= 3 and "tool" in args and "install" in args:
+        # uv tool install — refresh PATH so subsequent shutil.which() finds the
+        # freshly-installed binary in the same Python process.
+        _refresh_path_for_uv_tools()
+    return ok, output or f"exit code {completed.returncode}"
 
 
 def _provider_install_command(provider_key: str) -> tuple[str, list[str]] | None:
@@ -418,27 +459,31 @@ def _offer_multiplexer_install(*, no_input: bool, stream: TextIO) -> None:
         "We need tmux (a terminal multiplexer that lets teammates appear in their own panes). "
         "Want me to try installing it for you?"
     )
+    theme = get_theme()
     if answer is None or not answer:
         if answer is False:
-            print("Okay — I will not install tmux. Manual steps will be shown below.", file=stream)
+            print(f"{theme.symbols['info']} {theme.muted('Okay — skipping tmux auto-install. Manual steps will be shown below.')}", file=stream)
         return
     command = _multiplexer_install_command()
     if command is None:
-        print("I could not find a package manager (brew/apt-get/dnf/pacman/apk) to install tmux automatically.", file=stream)
+        print(f"{theme.symbols['warn']} {theme.warn('No package manager found')} {theme.muted('(brew / apt-get / dnf / pacman / apk) to install tmux automatically.')}", file=stream)
         return
     display, argv = command
-    print(f"Trying: {display}", file=stream)
+    print(f"{theme.symbols['arrow']} {theme.heading('Running:')} {theme.accent(display)}", file=stream)
     if argv and argv[0] == "sudo":
-        print("(You may be prompted for your sudo password.)", file=stream)
+        print(f"{theme.symbols['info']} {theme.muted('You may be prompted for your sudo password.')}", file=stream)
     ok, output = _run_install_command(argv)
     if ok:
-        print("Installed tmux. Continuing with claude-anyteam setup.", file=stream)
+        print(f"{theme.symbols['success']} {theme.success('Installed tmux.')} {theme.muted('Continuing with claude-anyteam setup.')}", file=stream)
         return
-    print("I tried to install tmux, but it failed.", file=stream)
-    print("Raw installer output:", file=stream)
-    for line in output.splitlines() or ["No output captured."]:
-        print(f"  {line}", file=stream)
-    print("Falling through to manual instructions below.", file=stream)
+    body = [
+        f"{theme.symbols['error']} {theme.heading('I tried to install tmux, but it failed.')}",
+        theme.muted("Raw installer output:"),
+        *(f"  {theme.muted(line)}" for line in (output.splitlines() or ["No output captured."])),
+        "",
+        theme.muted("Falling through to manual instructions below."),
+    ]
+    print(render_box(theme.danger("tmux auto-install failed"), body, "red", theme=theme), file=stream)
 
 
 def _offer_provider_dependency_installs(*, no_input: bool, stream: TextIO) -> None:
@@ -451,9 +496,10 @@ def _offer_provider_dependency_installs(*, no_input: bool, stream: TextIO) -> No
     if not missing:
         return
 
+    theme = get_theme()
     if no_input or not (sys.stdin.isatty() and sys.stdout.isatty()):
         print(
-            "Skipping interactive dependency install because this terminal cannot answer questions; manual steps are shown below.",
+            f"{theme.symbols['info']} {theme.muted('Skipping interactive dependency install (this terminal cannot answer questions); manual steps follow below.')}",
             file=stream,
         )
         return
@@ -463,37 +509,43 @@ def _offer_provider_dependency_installs(*, no_input: bool, stream: TextIO) -> No
             f"We need {label} for {key}-* teammates. Want me to try installing it for you?"
         )
         if answer is None:
-            print(f"Skipping {label} auto-install; manual steps will be shown below.", file=stream)
+            print(f"{theme.symbols['info']} {theme.muted(f'Skipping {label} auto-install; manual steps will be shown below.')}", file=stream)
             continue
         if not answer:
-            print(f"Okay — I will not install {label}. Manual steps will be shown below.", file=stream)
+            print(f"{theme.symbols['info']} {theme.muted(f'Okay — skipping {label}. Manual steps will be shown below.')}", file=stream)
             continue
         command = _provider_install_command(key)
         if command is None:
-            print(f"I could not find the installer tool for {label}. Try this next:", file=stream)
+            print(f"{theme.symbols['warn']} {theme.warn(f'No installer tool found for {label}.')} {theme.muted('Try this next:')}", file=stream)
             for idx, step in enumerate(_manual_provider_steps(key), start=1):
-                print(f"  {idx}. {step}", file=stream)
-            print("Still stuck? Report it:", file=stream)
+                print(f"  {theme.muted(f'{idx}.')} {step}", file=stream)
+            print(theme.muted("Still stuck? Report it:"), file=stream)
             print(
                 f"  {_issue_url(title=f'{label} installer tool missing', raw_error=f'No installer command found for {label}')}",
                 file=stream,
             )
             continue
         display, argv = command
-        print(f"Trying: {display}", file=stream)
+        print(f"{theme.symbols['arrow']} {theme.heading('Running:')} {theme.accent(display)}", file=stream)
         ok, output = _run_install_command(argv)
         if ok:
-            print(f"Installed {label}. You may still need to sign in before teammates can use it.", file=stream)
+            print(
+                f"{theme.symbols['success']} {theme.success(f'Installed {label}.')} {theme.muted('You may still need to sign in before teammates can use it.')}",
+                file=stream,
+            )
         else:
-            print(f"I tried to install {label}, but it failed.", file=stream)
-            print("Raw installer output:", file=stream)
-            for line in output.splitlines() or ["No output captured."]:
-                print(f"  {line}", file=stream)
-            print("Try this next:", file=stream)
-            for idx, step in enumerate(_manual_provider_steps(key), start=1):
-                print(f"  {idx}. {step}", file=stream)
-            print("Still stuck? Report it:", file=stream)
-            print(f"  {_issue_url(title=f'{label} auto-install failed', raw_error=output)}", file=stream)
+            body = [
+                f"{theme.symbols['error']} {theme.heading(f'I tried to install {label}, but it failed.')}",
+                theme.muted("Raw installer output:"),
+                *(f"  {theme.muted(line)}" for line in (output.splitlines() or ["No output captured."])),
+                "",
+                theme.muted("Try this next:"),
+                *(f"  {theme.muted(f'{idx}.')} {step}" for idx, step in enumerate(_manual_provider_steps(key), start=1)),
+                "",
+                theme.muted("Still stuck? Report it:"),
+                f"  {theme.accent(_issue_url(title=f'{label} auto-install failed', raw_error=output))}",
+            ]
+            print(render_box(theme.danger(f"{label} auto-install failed"), body, "red", theme=theme), file=stream)
 
 
 def _install_command(

--- a/src/claude_anyteam/installer.py
+++ b/src/claude_anyteam/installer.py
@@ -27,6 +27,8 @@ from pathlib import Path
 from typing import Any, Callable, Literal
 from urllib.parse import urlencode
 
+from ._theme import get_theme, render_box
+
 TEAMMATE_COMMAND_KEY = "CLAUDE_CODE_TEAMMATE_COMMAND"
 TEAMMATE_BINARY_KEY = "CLAUDE_ANYTEAM_BINARY"
 GEMINI_TEAMMATE_BINARY_KEY = "CLAUDE_ANYTEAM_GEMINI_BINARY"
@@ -2943,11 +2945,11 @@ def _format_no_provider_ready_message(
 
 def _format_soft_diagnostic(diagnostic: InstallError) -> str:
     raw_error = diagnostic.as_plain_text(include_details=True, include_report=False)
-    lines = [
+    plain_lines = [
         f"Warning: {diagnostic.title}",
         diagnostic.explanation,
     ]
-    lines.extend(
+    plain_lines.extend(
         format_installer_diagnostic(
             summary=diagnostic.explanation,
             raw_error=raw_error,
@@ -2956,11 +2958,19 @@ def _format_soft_diagnostic(diagnostic: InstallError) -> str:
             include_what_happened=False,
         )
     )
-    lines.append(f"Severity: {diagnostic.severity}")
+    plain_lines.append(f"Severity: {diagnostic.severity}")
     if diagnostic.details:
-        lines.append("Raw details (for debugging):")
-        lines.extend(f"  {line}" for line in diagnostic.details.splitlines())
-    return "\n".join(lines)
+        plain_lines.append("Raw details (for debugging):")
+        plain_lines.extend(f"  {line}" for line in diagnostic.details.splitlines())
+
+    theme = get_theme()
+    if theme.color and sys.stderr.isatty():
+        body = [theme.muted(line) if line.startswith(("Severity:", "Raw details")) or line.startswith("  ")
+                else theme.heading(line) if line == diagnostic.explanation
+                else line
+                for line in plain_lines[1:]]  # skip the title; it goes in the box header
+        return render_box(theme.warn(f"Warning: {diagnostic.title}"), body, "yellow", theme=theme)
+    return "\n".join(plain_lines)
 
 
 def format_install_message(result: InstallResult, *, include_provider_status: bool = True) -> str:
@@ -3029,7 +3039,27 @@ def format_install_message(result: InstallResult, *, include_provider_status: bo
     receipt_lines.append("Restart Claude Code for the changes to take effect. Use codex-*, gemini-*, or kimi-* teammate names to route to the matching backend.")
     if not result.changed_anything:
         receipt_lines.insert(1, "The existing settings already matched this install.")
-    lines.append("\n".join(receipt_lines))
+
+    # Beautify at display time only when stdout is a real TTY. Tests capture
+    # plain output for substring assertions; users get the boxed/themed view.
+    theme = get_theme()
+    if theme.color and sys.stdout.isatty():
+        themed_lines = []
+        for line in receipt_lines:
+            if line.startswith("Updated ") or line.startswith("Set ") or line.startswith("Removed "):
+                themed_lines.append(f"{theme.symbols['success']} {line}")
+            elif line.startswith("Restart Claude Code"):
+                themed_lines.append("")
+                themed_lines.append(f"{theme.symbols['warn']} {theme.warn(line)}")
+            elif "already" in line and "no change" in line:
+                themed_lines.append(f"{theme.symbols['info']} {theme.muted(line)}")
+            elif line.startswith("Permission allowlist written"):
+                themed_lines.append(f"{theme.symbols['success']} {line}")
+            else:
+                themed_lines.append(f"{theme.symbols['info']} {line}")
+        lines.append(render_box(theme.success("Setup applied"), themed_lines, "green", theme=theme))
+    else:
+        lines.append("\n".join(receipt_lines))
     return "\n\n".join(lines)
 
 

--- a/tests/test_npm_package.py
+++ b/tests/test_npm_package.py
@@ -12,7 +12,7 @@ def test_npm_package_metadata_matches_installer_contract() -> None:
     package = json.loads((NPM_DIR / 'package.json').read_text(encoding='utf-8'))
 
     assert package['name'] == 'claude-anyteam'
-    assert package['version'] == '0.7.1'
+    assert package['version'] == '0.7.2'
     assert package['bin']['claude-anyteam-setup'] == 'bin/setup.js'
     assert package['bin']['claude-anyteam'] == 'bin/setup.js'
     assert package['scripts']['postinstall'] == 'node bin/setup.js --postinstall'

--- a/uv.lock
+++ b/uv.lock
@@ -132,7 +132,7 @@ wheels = [
 
 [[package]]
 name = "claude-anyteam"
-version = "0.7.1"
+version = "0.7.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Why

User report on v0.7.1:
- Kimi auto-install reported success but the subsequent provider-status table said it wasn't installed.
- The Python installer's output was \"completely white, ugly, not beautified\" — visual inconsistency between the colored npm wrapper and the plain Python child it spawned.
- Wanted releases to fire automatically on merge instead of needing a separate \`gh release create\`.

## Three fixes

### 1. PATH refresh after \`uv tool install\`
\`cli._refresh_path_for_uv_tools()\`: after a successful uv tool install, queries \`uv tool dir --bin\` and prepends it to \`os.environ[\"PATH\"]\` so the next \`shutil.which()\` probe finds the freshly-installed binary in the same Python process. Fixes the kimi false-negative the user hit on Windows where uv tools land in \`%APPDATA%\\Local\\uv\\tools\\bin\` which isn't always on the calling shell's PATH.

### 2. Python theme module + applied throughout
New \`src/claude_anyteam/_theme.py\` mirrors \`npm/lib/art.js\` — pure stdlib ANSI helpers + \`render_box\` with word-wrap and unicode/ASCII fallback. Honors \`LC_ALL=C\` and legacy Windows cmd codepage; calls \`SetConsoleMode\` on Windows to enable VT processing.

Applied to:
- **Prompts** (\`[Y/n]\`) — colored \`●\` info glyph, bold heading, muted bracket
- **Auto-install attempts** — \`→ Running: <command>\` accent + sudo notice + green \`✔ Installed X\` success / red boxed failure block with raw output, manual steps, prefilled GitHub issue link
- **Receipt block** (\`format_install_message\`) — when stdout is a TTY, wraps the receipt in a green \"Setup applied\" box with themed prefix glyphs; tests still get plain text via the non-TTY branch
- **Soft diagnostic warnings** — yellow boxed format on a TTY, plain text in tests

### 3. Auto-release workflow
\`.github/workflows/auto-release.yml\` fires on every push to main that touches \`package.json\` or \`pyproject.toml\`. Verifies both manifests agree on the version, then creates a \`v\$VERSION\` tag + GitHub release with the merged PR's body as release notes (falls back to commit message). Idempotent — skips if the tag already exists. Pushing the tag triggers the existing \`release.yml\` publish pipeline. Means a merge to main is now the only manual step needed to ship.

## Tests

- 129 pytest pass (TTY-gated theming keeps existing substring assertions green via the plain-text branch)
- 26 Node tests pass

## Commits

- \`5e38d68\` v0.7.2 — beautify Python installer output, refresh PATH after uv install, auto-release on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)