### PR TITLE
v0.7.3 — fix auto-release → publish chain

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -88,3 +88,17 @@ jobs:
             --title "$title" \
             --notes-file "${{ steps.notes.outputs.notes_path }}"
           echo "Released $tag (notes from ${{ steps.notes.outputs.source }})."
+
+      - name: Trigger publish pipeline
+        if: steps.check_tag.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # Tags created by GITHUB_TOKEN do NOT fire `push: tags:` triggers
+        # (Action security restriction). Dispatch release.yml explicitly so
+        # publish-to-npm + publish-to-pypi actually run after auto-tag.
+        # workflow_dispatch IS allowed under GITHUB_TOKEN.
+        run: |
+          set -euo pipefail
+          tag="v${{ steps.ver.outputs.version }}"
+          gh workflow run release.yml --ref main -f tag="$tag"
+          echo "Dispatched release.yml for $tag."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,21 @@
 name: Release
 
+# Triggered by either a real `v*` tag push (a maintainer pushing a tag from
+# their machine) OR an explicit `workflow_dispatch` from auto-release.yml.
+# The dispatch path is what makes the auto-release flow work end-to-end:
+# tags created by GITHUB_TOKEN inside an Action do NOT trigger downstream
+# `push: tags:` workflows (security restriction), so auto-release.yml has
+# to call this workflow explicitly via `gh workflow run`.
 on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to publish (e.g. v0.7.3). Defaults to the workflow ref.'
+        required: false
+        type: string
 
 concurrency:
   group: release-${{ github.ref }}
@@ -15,6 +27,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
       - name: Install uv
         uses: astral-sh/setup-uv@v4
       - name: Set up Python
@@ -33,6 +47,8 @@ jobs:
       id-token: write  # required by --provenance
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
@@ -51,6 +67,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
       - name: Install uv
         uses: astral-sh/setup-uv@v4
       - name: Build distributions

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-anyteam",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Beautiful zero-friction installer for claude-anyteam in Claude Code.",
   "type": "module",
   "bin": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "claude-anyteam"
-version = "0.7.2"
+version = "0.7.3"
 description = "Bring Codex, Gemini, and Kimi CLI powered teammates into Claude Code with multi-backend routing."
 requires-python = ">=3.12"
 license = "MIT"

--- a/tests/test_npm_package.py
+++ b/tests/test_npm_package.py
@@ -12,7 +12,7 @@ def test_npm_package_metadata_matches_installer_contract() -> None:
     package = json.loads((NPM_DIR / 'package.json').read_text(encoding='utf-8'))
 
     assert package['name'] == 'claude-anyteam'
-    assert package['version'] == '0.7.2'
+    assert package['version'] == '0.7.3'
     assert package['bin']['claude-anyteam-setup'] == 'bin/setup.js'
     assert package['bin']['claude-anyteam'] == 'bin/setup.js'
     assert package['scripts']['postinstall'] == 'node bin/setup.js --postinstall'

--- a/uv.lock
+++ b/uv.lock
@@ -132,7 +132,7 @@ wheels = [
 
 [[package]]
 name = "claude-anyteam"
-version = "0.7.2"
+version = "0.7.3"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Why

PR #17 added \`auto-release.yml\` so a version-bump merge would auto-tag and publish. The auto-tag worked but **release.yml never fired** for v0.7.2 — the published versions on npm + PyPI were stale, and shipping needed a manual local tag re-push.

Root cause: GitHub Actions security restriction. **Tags created using \`GITHUB_TOKEN\` inside an Action do NOT trigger downstream \`push: tags:\` workflows.** Documented at https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow

## Fix

- Add \`workflow_dispatch\` trigger to release.yml with an optional \`tag\` input. Each job's checkout uses \`\${{ inputs.tag || github.ref }}\` so dispatched runs check out the just-created tag rather than the main branch.
- auto-release.yml gains a final \`Trigger publish pipeline\` step: \`gh workflow run release.yml --ref main -f tag=\"v\$VERSION\"\`. \`workflow_dispatch\` IS allowed under \`GITHUB_TOKEN\`, so this completes the chain without requiring a maintainer PAT.

## Net effect

A merge to main that bumps the version now triggers:
1. \`auto-release.yml\` — verifies manifests agree, creates v\$VERSION tag + GitHub release with PR body as notes
2. \`release.yml\` (dispatched) — runs tests, publishes to npm with provenance, publishes to PyPI

No manual \`gh release create\` and no manual local tag push needed.

## This PR also serves as the end-to-end smoke test

Once merged, v0.7.3 will validate the full chain.

## Tests

- 129 pytest pass
- 26 Node tests pass