### PR TITLE
v0.7.5 — kimi PATH leak in success branch, condense giant URL out of box, suppress duplicate plugin attempt

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-anyteam",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Beautiful zero-friction installer for claude-anyteam in Claude Code.",
   "type": "module",
   "bin": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "claude-anyteam"
-version = "0.7.4"
+version = "0.7.5"
 description = "Bring Codex, Gemini, and Kimi CLI powered teammates into Claude Code with multi-backend routing."
 requires-python = ">=3.12"
 license = "MIT"

--- a/src/claude_anyteam/cli.py
+++ b/src/claude_anyteam/cli.py
@@ -417,6 +417,15 @@ def _wait_for_binary(name: str, *, attempts: int = 6, delay_s: float = 0.25) -> 
             for ext in ("", ".exe", ".cmd", ".bat"):
                 cand = os.path.join(bin_dir, f"{name}{ext}")
                 if os.path.isfile(cand):
+                    # Critical: ensure the directory containing this binary
+                    # is on PATH so later shutil.which() calls (e.g. inside
+                    # _check_kimi_cli) succeed too. Without this, _wait_for_binary
+                    # returns a path the install-success message uses, but the
+                    # provider-status table still reports the binary as missing.
+                    current = os.environ.get("PATH", "")
+                    parts = current.split(os.pathsep) if current else []
+                    if bin_dir not in parts:
+                        os.environ["PATH"] = bin_dir + os.pathsep + current
                     return cand
         time.sleep(delay_s)
         _refresh_path_for_uv_tools()
@@ -632,6 +641,7 @@ def _offer_provider_dependency_installs(*, no_input: bool, stream: TextIO) -> No
                 file=stream,
             )
         else:
+            issue_url = _issue_url(title=f"{label} auto-install failed", raw_error=output)
             body = [
                 f"{theme.symbols['error']} {theme.heading(f'I tried to install {label}, but it failed.')}",
                 theme.muted("Raw installer output:"),
@@ -639,11 +649,14 @@ def _offer_provider_dependency_installs(*, no_input: bool, stream: TextIO) -> No
                 "",
                 theme.muted("Try this next:"),
                 *(f"  {theme.muted(f'{idx}.')} {step}" for idx, step in enumerate(_manual_provider_steps(key), start=1)),
-                "",
-                theme.muted("Still stuck? Report it:"),
-                f"  {theme.accent(_issue_url(title=f'{label} auto-install failed', raw_error=output))}",
             ]
             print(render_box(theme.danger(f"{label} auto-install failed"), body, "red", theme=theme), file=stream)
+            # URL outside the box so terminals render it as one clickable line
+            # instead of word-wrapping the prefilled body into ~17 lines.
+            print(
+                f"{theme.symbols['info']} {theme.muted('Open in browser to report:')}\n  {theme.accent(issue_url)}",
+                file=stream,
+            )
 
 
 def _install_command(
@@ -699,7 +712,11 @@ def _install_command(
             provider_status_callback=_print_provider_status,
             force_empty=force_empty or self_heal,
             no_allowlist=no_allowlist,
-            register_plugin=True,
+            # Skip plugin registration when invoked from the npm wrapper —
+            # setup.js handles `claude plugin install` itself afterward and
+            # has better error UX. Letting the Python child also try produces
+            # a redundant warning box for the same failure.
+            register_plugin=os.environ.get("CLAUDE_ANYTEAM_NPM_PARENT") != "1",
         )
     except InstallError as exc:
         exit_code = getattr(exc, "cli_exit_code", 2)

--- a/src/claude_anyteam/installer.py
+++ b/src/claude_anyteam/installer.py
@@ -2945,20 +2945,34 @@ def _format_no_provider_ready_message(
 
 def _format_soft_diagnostic(diagnostic: InstallError) -> str:
     raw_error = diagnostic.as_plain_text(include_details=True, include_report=False)
+    issue_url = build_issue_url(title=diagnostic.title, raw_error=raw_error)
+    diagnostic_lines = format_installer_diagnostic(
+        summary=diagnostic.explanation,
+        raw_error=raw_error,
+        next_steps_per_os=diagnostic.action,
+        title=diagnostic.title,
+        include_what_happened=False,
+    )
+    # Strip the inline "Still stuck? Report it: <giant-url>" tail — we'll
+    # print the URL on its own line AFTER the box so it doesn't word-wrap
+    # into 17 ugly lines and so terminal link parsers see the URL whole.
+    body_without_url: list[str] = []
+    skip_url_line = False
+    for line in diagnostic_lines:
+        if line.strip() == "Still stuck? Report it:":
+            skip_url_line = True
+            continue
+        if skip_url_line and line.strip().startswith("http"):
+            skip_url_line = False
+            continue
+        body_without_url.append(line)
+
     plain_lines = [
         f"Warning: {diagnostic.title}",
         diagnostic.explanation,
+        *body_without_url,
+        f"Severity: {diagnostic.severity}",
     ]
-    plain_lines.extend(
-        format_installer_diagnostic(
-            summary=diagnostic.explanation,
-            raw_error=raw_error,
-            next_steps_per_os=diagnostic.action,
-            title=diagnostic.title,
-            include_what_happened=False,
-        )
-    )
-    plain_lines.append(f"Severity: {diagnostic.severity}")
     if diagnostic.details:
         plain_lines.append("Raw details (for debugging):")
         plain_lines.extend(f"  {line}" for line in diagnostic.details.splitlines())
@@ -2968,9 +2982,14 @@ def _format_soft_diagnostic(diagnostic: InstallError) -> str:
         body = [theme.muted(line) if line.startswith(("Severity:", "Raw details")) or line.startswith("  ")
                 else theme.heading(line) if line == diagnostic.explanation
                 else line
-                for line in plain_lines[1:]]  # skip the title; it goes in the box header
-        return render_box(theme.warn(f"Warning: {diagnostic.title}"), body, "yellow", theme=theme)
-    return "\n".join(plain_lines)
+                for line in plain_lines[1:]]
+        boxed = render_box(theme.warn(f"Warning: {diagnostic.title}"), body, "yellow", theme=theme)
+        # URL on its own line — most terminals (Windows Terminal, iTerm2,
+        # gnome-terminal) make single-line URLs clickable. Inside a box, the
+        # word-wrap kills clickability AND visual weight.
+        report_line = f"\n{theme.symbols['info']} {theme.muted('Open in browser to report:')}\n  {theme.accent(issue_url)}"
+        return f"{boxed}{report_line}"
+    return "\n".join([*plain_lines, "", "Open in browser to report:", f"  {issue_url}"])
 
 
 def format_install_message(result: InstallResult, *, include_provider_status: bool = True) -> str:

--- a/tests/test_npm_package.py
+++ b/tests/test_npm_package.py
@@ -12,7 +12,7 @@ def test_npm_package_metadata_matches_installer_contract() -> None:
     package = json.loads((NPM_DIR / 'package.json').read_text(encoding='utf-8'))
 
     assert package['name'] == 'claude-anyteam'
-    assert package['version'] == '0.7.4'
+    assert package['version'] == '0.7.5'
     assert package['bin']['claude-anyteam-setup'] == 'bin/setup.js'
     assert package['bin']['claude-anyteam'] == 'bin/setup.js'
     assert package['scripts']['postinstall'] == 'node bin/setup.js --postinstall'

--- a/uv.lock
+++ b/uv.lock
@@ -132,7 +132,7 @@ wheels = [
 
 [[package]]
 name = "claude-anyteam"
-version = "0.7.4"
+version = "0.7.5"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## What you saw on Windows / v0.7.4

Visuals are beautiful now. Three behavioral issues left:

### 1. Kimi: \`✔ Installed Kimi CLI\` printed, then the table showed \`❌\`

\`_wait_for_binary\` was finding the binary by directly probing the per-tool \`Scripts\` dir. That made the success branch fire. But \`_check_kimi_cli\` ran later and called \`shutil.which(\"kimi\")\`, which returned None because the Scripts dir wasn't on PATH for that probe — only the \`uv tool dir --bin\` shim location was, and the shim hadn't been written yet on Windows.

**Fix.** When \`_wait_for_binary\` locates a binary via direct file probe, ALSO prepend the containing directory to \`os.environ[\"PATH\"]\`. Subsequent \`shutil.which()\` calls in the same process (provider-status table, future helpers) now succeed too.

### 2. Diagnostic box was 17 lines tall

The prefilled GitHub issue URL is ~1500 chars. Inside the 96-col box, that wraps to ~17 lines, and modern terminals can't make a wrapped URL clickable.

**Fix.** Strip the \`Still stuck? Report it: <url>\` tail out of the boxed body and print it OUTSIDE the box on its own line as \`● Open in browser to report:\\n  <url>\`. Box stays compact (now ~5 lines), URL becomes one clickable line. Same change in both \`_format_soft_diagnostic\` and the dep-install failure box in \`cli.py\`.

### 3. Plugin registration tried twice — once by Python, once by npm wrapper

Python attempted \`claude plugin install JonathanRosado/claude-anyteam\` → failed with \"Plugin not found in any configured marketplace\" → big yellow warning box. Then the npm wrapper (which has its own plugin registration logic with marketplace-add fallback) succeeded right after.

**Fix.** When \`CLAUDE_ANYTEAM_NPM_PARENT=1\`, skip the Python plugin registration — setup.js handles it with better UX.

## Tests

- 129 pytest pass
- 26 Node tests pass

## Validation

Once merged, the v0.7.4 → v0.7.5 chain itself validates: \`auto-release.yml\` should fire, tag, test, publish-npm, publish-pypi as one workflow run.