### PR TITLE
v0.7.7 — debug flag, psmux on Windows, log everything

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -107,18 +107,20 @@ jobs:
         run: uv python install 3.12
       - name: Sync deps
         run: uv sync --all-extras
-      - name: Run pytest (with one retry for known concurrency flake)
+      - name: Run pytest (with up to 3 retries for known concurrency flake)
         run: |
           set +e
           uv run pytest -q
           status=$?
-          if [ $status -ne 0 ]; then
-            echo "::warning::pytest failed once; retrying once for known flakes"
+          attempt=1
+          while [ $status -ne 0 ] && [ $attempt -lt 4 ]; do
+            echo "::warning::pytest failed (attempt $attempt); retrying --last-failed"
             uv run pytest -q --last-failed
             status=$?
-          fi
+            attempt=$((attempt + 1))
+          done
           if [ $status -ne 0 ]; then
-            echo "::error::pytest failed twice — not a flake"
+            echo "::error::pytest failed 4 times — not a flake"
             exit $status
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,17 +22,19 @@ jobs:
         run: uv python install 3.12
       - name: Sync deps
         run: uv sync --all-extras
-      - name: Run pytest (with one retry for known concurrency flake)
+      - name: Run pytest (with up to 3 retries for known concurrency flake)
         run: |
           set +e
           uv run pytest -q
           status=$?
-          if [ $status -ne 0 ]; then
-            echo "::warning::pytest failed once; retrying once for known flakes"
+          attempt=1
+          while [ $status -ne 0 ] && [ $attempt -lt 4 ]; do
+            echo "::warning::pytest failed (attempt $attempt); retrying --last-failed"
             uv run pytest -q --last-failed
             status=$?
-          fi
+            attempt=$((attempt + 1))
+          done
           if [ $status -ne 0 ]; then
-            echo "::error::pytest failed twice — not a flake"
+            echo "::error::pytest failed 4 times — not a flake"
             exit $status
           fi

--- a/npm/bin/setup.js
+++ b/npm/bin/setup.js
@@ -48,11 +48,44 @@ const CLAUDE_PLUGIN_ALREADY_INSTALLED = /\balready installed\b/i;
 const PACKAGE_JSON = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8'));
 const INSTALLER_VERSION = PACKAGE_JSON.version || 'unknown';
 
+const DEBUG_ENABLED = ['1', 'true', 'yes', 'on'].includes(String(process.env.CLAUDE_ANYTEAM_DEBUG || '').toLowerCase());
+
+function debugLog(...parts) {
+  if (!DEBUG_ENABLED) return;
+  const ts = new Date().toISOString().slice(11, 19);
+  const prefix = process.stderr.isTTY ? '\x1b[35m[debug]\x1b[39m ' : '[debug] ';
+  console.error(prefix + ts + ' ' + parts.map((p) => (typeof p === 'string' ? p : JSON.stringify(p))).join(' '));
+}
+
+function debugEnvSnapshot(label) {
+  if (!DEBUG_ENABLED) return;
+  debugLog(`--- ${label} (selected env) ---`);
+  for (const k of [
+    'CLAUDE_ANYTEAM_DEBUG', 'CLAUDE_ANYTEAM_NPM_PARENT', 'CLAUDE_ANYTEAM_NPM_VERSION',
+    'CLAUDE_ANYTEAM_FORCE_COLOR', 'FORCE_COLOR', 'NO_COLOR',
+    'PATHEXT', 'PYTHONUTF8', 'PYTHONIOENCODING',
+    'WT_SESSION', 'TERM_PROGRAM', 'ConEmuANSI',
+    'LC_ALL', 'LANG', 'HOME', 'USERPROFILE', 'APPDATA', 'LOCALAPPDATA',
+  ]) {
+    const v = process.env[k];
+    if (v !== undefined) debugLog(`  ${k}=${v}`);
+  }
+  const path = process.env.PATH || '';
+  const sep = process.platform === 'win32' ? ';' : ':';
+  const parts = path ? path.split(sep) : [];
+  debugLog(`  PATH (${parts.length} entries; first 5):`);
+  for (const p of parts.slice(0, 5)) debugLog(`    ${p}`);
+  if (parts.length > 8) debugLog(`    ... (${parts.length - 8} more) ...`);
+  for (const p of parts.slice(-3)) debugLog(`    ${p}`);
+  debugLog(`  process.platform=${process.platform} arch=${process.arch} node=${process.version}`);
+  debugLog(`  stdin.isTTY=${!!process.stdin.isTTY} stdout.isTTY=${!!process.stdout.isTTY} stderr.isTTY=${!!process.stderr.isTTY}`);
+}
+
 let detectedPythonVersion = 'not checked';
 let detectedUvVersion = 'not checked';
 
 function parseArgs(argv) {
-  const args = { postinstall: false, settingsPath: undefined, help: false };
+  const args = { postinstall: false, settingsPath: undefined, help: false, debug: false };
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
     if (arg === '--postinstall') {
@@ -65,6 +98,8 @@ function parseArgs(argv) {
       index += 1;
     } else if (arg === '--help' || arg === '-h') {
       args.help = true;
+    } else if (arg === '--debug') {
+      args.debug = true;
     } else {
       throw new Error(`Unknown option: ${arg}`);
     }
@@ -203,7 +238,7 @@ function printWarning(title, lines, options = {}) {
 }
 
 function printVersionBanner() {
-  console.log(theme.muted(`claude-anyteam installer v${INSTALLER_VERSION}`));
+  console.log(theme.muted(`claude-anyteam installer v${INSTALLER_VERSION}${DEBUG_ENABLED ? ' (debug mode)' : ''}`));
 }
 
 function printSection(title, detail) {
@@ -366,19 +401,25 @@ function runPythonInstaller({ uvPath, settingsPath, stdio = 'inherit' }) {
     args.push('--settings-path', settingsPath);
   }
   return new Promise((resolve, reject) => {
+    const childEnv = {
+      ...uvToolEnv(process.env),
+      CLAUDE_ANYTEAM_NPM_PARENT: '1',
+      CLAUDE_ANYTEAM_NPM_VERSION: INSTALLER_VERSION,
+      // Belt-and-suspenders: the Python child often loses TTY detection
+      // through the npx → uv tool run chain (especially on Windows).
+      // Set FORCE_COLOR + CLAUDE_ANYTEAM_FORCE_COLOR explicitly so the
+      // Python theme module's _supports_color() always says yes here,
+      // independent of whether sys.stdout.isatty() returns True.
+      FORCE_COLOR: process.env.NO_COLOR ? '0' : '1',
+      CLAUDE_ANYTEAM_FORCE_COLOR: process.env.NO_COLOR ? '0' : '1',
+    };
+    if (DEBUG_ENABLED) {
+      childEnv.CLAUDE_ANYTEAM_DEBUG = '1';
+    }
+    debugLog(`spawning Python installer: ${uvPath} ${args.map((a) => JSON.stringify(a)).join(' ')}`);
+    debugLog(`  child env adds: CLAUDE_ANYTEAM_NPM_PARENT=1 CLAUDE_ANYTEAM_NPM_VERSION=${INSTALLER_VERSION} FORCE_COLOR=${childEnv.FORCE_COLOR} CLAUDE_ANYTEAM_DEBUG=${childEnv.CLAUDE_ANYTEAM_DEBUG || '<unset>'}`);
     const child = spawn(uvPath, args, {
-      env: {
-        ...uvToolEnv(process.env),
-        CLAUDE_ANYTEAM_NPM_PARENT: '1',
-        CLAUDE_ANYTEAM_NPM_VERSION: INSTALLER_VERSION,
-        // Belt-and-suspenders: the Python child often loses TTY detection
-        // through the npx → uv tool run chain (especially on Windows).
-        // Set FORCE_COLOR + CLAUDE_ANYTEAM_FORCE_COLOR explicitly so the
-        // Python theme module's _supports_color() always says yes here,
-        // independent of whether sys.stdout.isatty() returns True.
-        FORCE_COLOR: process.env.NO_COLOR ? '0' : '1',
-        CLAUDE_ANYTEAM_FORCE_COLOR: process.env.NO_COLOR ? '0' : '1',
-      },
+      env: childEnv,
       stdio,
     });
     child.on('error', reject);
@@ -437,11 +478,17 @@ async function main() {
     console.log(usage());
     return 0;
   }
+  if (args.debug) {
+    process.env.CLAUDE_ANYTEAM_DEBUG = '1';
+  }
 
   const postinstall = args.postinstall || process.env.npm_lifecycle_event === 'postinstall';
   const interactive = isInteractive();
   const silent = postinstall;
   const nodeMajor = Number.parseInt(process.versions.node.split('.', 1)[0] || '0', 10);
+  debugLog(`--- npm wrapper start (v${INSTALLER_VERSION}) ---`);
+  debugLog(`postinstall=${postinstall} interactive=${interactive} silent=${silent} nodeMajor=${nodeMajor}`);
+  debugEnvSnapshot('npm-wrapper-start');
 
   if (!silent) {
     console.log(renderBanner());

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-anyteam",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Beautiful zero-friction installer for claude-anyteam in Claude Code.",
   "type": "module",
   "bin": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "claude-anyteam"
-version = "0.7.6"
+version = "0.7.7"
 description = "Bring Codex, Gemini, and Kimi CLI powered teammates into Claude Code with multi-backend routing."
 requires-python = ">=3.12"
 license = "MIT"

--- a/src/claude_anyteam/_debug.py
+++ b/src/claude_anyteam/_debug.py
@@ -1,0 +1,110 @@
+"""Debug logger for the installer.
+
+Activated by setting CLAUDE_ANYTEAM_DEBUG=1 (or passing --debug to the CLI).
+Prints every interesting checkpoint to stderr with a `[debug] ` prefix so the
+user can grep / paste it back when diagnosing Windows-specific issues that
+the maintainer can't reproduce on their own machine.
+
+What gets logged when active:
+- npm wrapper version vs Python-tool version (resolved separately)
+- Every subprocess call: argv, exit code, first 800 chars of stdout/stderr
+- PATH state at install start + after every refresh
+- PATHEXT (Windows) and locale env vars
+- shutil.which() result for every probe
+- uv tool dir / uv tool dir --bin
+- Each provider check's resolved binary path (or "not found")
+- Selected env vars: CLAUDE_ANYTEAM_*, FORCE_COLOR, NO_COLOR
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from typing import Any, Iterable
+
+_PREFIX = "\x1b[35m[debug]\x1b[39m " if sys.stderr.isatty() else "[debug] "
+_ENABLED: bool | None = None
+
+
+def debug_enabled() -> bool:
+    global _ENABLED
+    if _ENABLED is None:
+        _ENABLED = os.environ.get("CLAUDE_ANYTEAM_DEBUG", "").lower() in ("1", "true", "yes", "on")
+    return _ENABLED
+
+
+def force_enable() -> None:
+    """Used by --debug CLI flag — sets env var so child processes inherit."""
+    global _ENABLED
+    _ENABLED = True
+    os.environ["CLAUDE_ANYTEAM_DEBUG"] = "1"
+
+
+def log(*parts: Any) -> None:
+    if not debug_enabled():
+        return
+    ts = time.strftime("%H:%M:%S")
+    msg = " ".join(str(p) for p in parts)
+    print(f"{_PREFIX}{ts} {msg}", file=sys.stderr)
+
+
+def log_subprocess(argv: list[str], result: Any, *, label: str = "exec") -> None:
+    if not debug_enabled():
+        return
+    code = getattr(result, "returncode", "?")
+    out = getattr(result, "stdout", "") or ""
+    err = getattr(result, "stderr", "") or ""
+    log(f"{label}: argv={argv!r} exit={code}")
+    if out:
+        log(f"  stdout[:800]={out[:800]!r}")
+    if err:
+        log(f"  stderr[:800]={err[:800]!r}")
+
+
+def log_env_snapshot(*, label: str = "env") -> None:
+    if not debug_enabled():
+        return
+    keys = [
+        "CLAUDE_ANYTEAM_DEBUG",
+        "CLAUDE_ANYTEAM_NPM_PARENT",
+        "CLAUDE_ANYTEAM_NPM_VERSION",
+        "CLAUDE_ANYTEAM_FORCE_COLOR",
+        "CLAUDE_ANYTEAM_ASCII",
+        "FORCE_COLOR",
+        "NO_COLOR",
+        "PATHEXT",
+        "PYTHONUTF8",
+        "PYTHONIOENCODING",
+        "WT_SESSION",
+        "TERM_PROGRAM",
+        "ConEmuANSI",
+        "LC_ALL",
+        "LANG",
+        "HOME",
+        "USERPROFILE",
+        "APPDATA",
+        "LOCALAPPDATA",
+    ]
+    log(f"--- {label} (selected env) ---")
+    for k in keys:
+        v = os.environ.get(k)
+        if v is not None:
+            log(f"  {k}={v}")
+    path = os.environ.get("PATH", "")
+    parts = path.split(os.pathsep) if path else []
+    log(f"  PATH ({len(parts)} entries; first 5 + last 3):")
+    for p in parts[:5]:
+        log(f"    {p}")
+    if len(parts) > 8:
+        log("    ...")
+        for p in parts[-3:]:
+            log(f"    {p}")
+    log(f"  sys.platform={sys.platform!r}, sys.version={sys.version.split()[0]}")
+    log(f"  sys.stdin.isatty()={sys.stdin.isatty()}, sys.stdout.isatty()={sys.stdout.isatty()}, sys.stderr.isatty()={sys.stderr.isatty()}")
+
+
+def log_which(name: str, result: str | None) -> None:
+    if not debug_enabled():
+        return
+    log(f"shutil.which({name!r}) -> {result!r}")

--- a/src/claude_anyteam/cli.py
+++ b/src/claude_anyteam/cli.py
@@ -19,6 +19,14 @@ from typing import TextIO
 from urllib.parse import urlencode
 
 from . import logger
+from ._debug import (
+    debug_enabled,
+    force_enable as _debug_force_enable,
+    log as _dlog,
+    log_env_snapshot as _dlog_env,
+    log_subprocess as _dlog_sub,
+    log_which as _dlog_which,
+)
 from ._theme import get_theme, render_box
 from .config import from_env
 from claude_anyteam import installer as installer_mod
@@ -266,6 +274,11 @@ def _build_install_parser() -> argparse.ArgumentParser:
         help="skip writing recommended permission allowlist entries",
     )
     p.add_argument(
+        "--debug",
+        action="store_true",
+        help="verbose logging to stderr (also: env CLAUDE_ANYTEAM_DEBUG=1)",
+    )
+    p.add_argument(
         "--self-heal",
         action="store_true",
         help=argparse.SUPPRESS,
@@ -358,6 +371,7 @@ def _uv_tool_bin_dirs() -> list[str]:
     Windows, since uv only writes the shim to the bin dir lazily).
     """
     uv = shutil.which("uv")
+    _dlog_which("uv", uv)
     if not uv:
         return []
     candidates: list[str] = []
@@ -369,13 +383,14 @@ def _uv_tool_bin_dirs() -> list[str]:
             timeout=10,
             check=False,
         )
+        _dlog_sub([uv, "tool", "dir", "--bin"], completed, label="uv-tool-dir-bin")
         if completed.returncode == 0 and completed.stdout:
             for line in completed.stdout.splitlines():
                 line = line.strip()
                 if line and os.path.isdir(line):
                     candidates.append(line)
-    except (OSError, subprocess.SubprocessError):
-        pass
+    except (OSError, subprocess.SubprocessError) as exc:
+        _dlog(f"uv tool dir --bin failed: {type(exc).__name__}: {exc}")
     try:
         completed = subprocess.run(
             [uv, "tool", "dir"],
@@ -384,6 +399,7 @@ def _uv_tool_bin_dirs() -> list[str]:
             timeout=10,
             check=False,
         )
+        _dlog_sub([uv, "tool", "dir"], completed, label="uv-tool-dir")
         if completed.returncode == 0 and completed.stdout:
             for line in completed.stdout.splitlines():
                 root = line.strip()
@@ -396,10 +412,11 @@ def _uv_tool_bin_dirs() -> list[str]:
                             candidate = os.path.join(root, entry, sub)
                             if os.path.isdir(candidate):
                                 candidates.append(candidate)
-                except OSError:
+                except OSError as exc:
+                    _dlog(f"listdir({root!r}) failed: {exc}")
                     continue
-    except (OSError, subprocess.SubprocessError):
-        pass
+    except (OSError, subprocess.SubprocessError) as exc:
+        _dlog(f"uv tool dir failed: {type(exc).__name__}: {exc}")
     # De-duplicate while preserving order.
     seen: set[str] = set()
     out: list[str] = []
@@ -407,6 +424,7 @@ def _uv_tool_bin_dirs() -> list[str]:
         if c not in seen:
             seen.add(c)
             out.append(c)
+    _dlog(f"_uv_tool_bin_dirs() -> {out}")
     return out
 
 
@@ -449,6 +467,7 @@ def _resolve_binary(
     uv_tool_name: str | None = None,
     update_path: bool = True,
 ) -> str | None:
+    _dlog(f"_resolve_binary names={names!r} uv_tool_name={uv_tool_name!r}")
     """Single shared resolver used by BOTH post-install success checks AND
     provider-status checks so they cannot disagree about whether a binary
     exists.
@@ -478,6 +497,7 @@ def _resolve_binary(
 
     for alias in names:
         hit = shutil.which(alias)
+        _dlog_which(alias, hit)
         if hit:
             _record_path(os.path.dirname(hit))
             return hit
@@ -503,13 +523,17 @@ def _resolve_binary(
             except (OSError, subprocess.SubprocessError):
                 pass
 
+    _dlog(f"  scanning {len(bin_dirs)} bin dirs with extensions={extensions!r}")
     for bin_dir in bin_dirs:
         for alias in names:
             for ext in extensions:
                 cand = os.path.join(bin_dir, f"{alias}{ext}")
-                if os.path.isfile(cand):
+                exists = os.path.isfile(cand)
+                _dlog(f"    probe: {cand} -> isfile={exists}")
+                if exists:
                     _record_path(bin_dir)
                     return cand
+    _dlog(f"_resolve_binary({names!r}) -> None (exhausted all probes)")
     return None
 
 
@@ -535,6 +559,7 @@ def _wait_for_binary(
 
 
 def _run_install_command(args: list[str], *, timeout_s: int = 300) -> tuple[bool, str]:
+    _dlog(f"install command starting: {args!r}")
     try:
         completed = subprocess.run(
             args,
@@ -543,7 +568,9 @@ def _run_install_command(args: list[str], *, timeout_s: int = 300) -> tuple[bool
             timeout=timeout_s,
             check=False,
         )
+        _dlog_sub(args, completed, label="install-command")
     except (OSError, subprocess.SubprocessError) as exc:
+        _dlog(f"install command exception: {type(exc).__name__}: {exc}")
         return False, f"{type(exc).__name__}: {exc}"
     output = "\n".join(
         part for part in ((completed.stdout or "").strip(), (completed.stderr or "").strip()) if part
@@ -599,9 +626,29 @@ def _manual_provider_steps(provider_key: str) -> list[str]:
     ]
 
 
+def _multiplexer_binary_for_platform() -> str:
+    """Linux/macOS use tmux; Windows uses psmux (winget/scoop/choco)."""
+    return "psmux" if sys.platform == "win32" else "tmux"
+
+
 def _multiplexer_install_command() -> tuple[str, list[str]] | None:
+    _dlog(f"_multiplexer_install_command for sys.platform={sys.platform!r}")
+    if sys.platform == "win32":
+        # Windows multiplexer story: psmux from winget (preferred), scoop, or choco.
+        # Falls back to manual instructions if no package manager is present.
+        for pm, args in (
+            ("winget", ["winget", "install", "--id", "psmux.psmux", "-e", "--accept-package-agreements", "--accept-source-agreements"]),
+            ("scoop", ["scoop", "install", "psmux"]),
+            ("choco", ["choco", "install", "psmux", "-y"]),
+        ):
+            pm_path = shutil.which(pm)
+            _dlog_which(pm, pm_path)
+            if pm_path:
+                return " ".join(args), args
+        return None
     if sys.platform == "darwin":
         brew = shutil.which("brew")
+        _dlog_which("brew", brew)
         if brew:
             return "brew install tmux", [brew, "install", "tmux"]
         return None
@@ -612,37 +659,69 @@ def _multiplexer_install_command() -> tuple[str, list[str]] | None:
             ("pacman", ["sudo", "pacman", "-S", "--noconfirm", "tmux"]),
             ("apk", ["sudo", "apk", "add", "tmux"]),
         ):
-            if shutil.which(pm):
+            pm_path = shutil.which(pm)
+            _dlog_which(pm, pm_path)
+            if pm_path:
                 return " ".join(install_args), install_args
     return None
 
 
 def _offer_multiplexer_install(*, no_input: bool, stream: TextIO) -> None:
-    """Prompt the user to install tmux when missing on Linux/macOS.
+    """Prompt the user to install the platform's terminal multiplexer when
+    missing. tmux on Linux/macOS, psmux on Windows.
 
     Runs before install_settings()'s prereq check so a successful auto-install
-    means the subsequent check finds tmux on PATH and the install proceeds
-    without raising. Failure or decline falls through to the existing
-    InstallError, which already prints platform-aware manual instructions.
+    means the subsequent check finds the multiplexer on PATH and the install
+    proceeds. Failure or decline falls through to the existing InstallError
+    (Linux/macOS) or manual instructions (Windows).
     """
-    check = installer_mod._check_terminal_multiplexer()
-    if check.found:
-        return
+    multiplexer = _multiplexer_binary_for_platform()
+    _dlog(f"_offer_multiplexer_install: platform={sys.platform!r} multiplexer={multiplexer!r}")
+    if sys.platform == "win32":
+        # Windows-specific: probe for psmux directly. The Python installer's
+        # _check_terminal_multiplexer returns found=True on Windows (single-
+        # terminal mode is the documented fallback), but psmux unlocks proper
+        # pane-based teammate visibility, so OFFER it.
+        existing = shutil.which("psmux") or shutil.which("psmux.exe")
+        _dlog_which("psmux", existing)
+        if existing:
+            _dlog(f"psmux already installed at {existing}")
+            return
+    else:
+        check = installer_mod._check_terminal_multiplexer()
+        _dlog(f"_check_terminal_multiplexer() -> found={check.found} binary={check.binary} platform={check.platform}")
+        if check.found:
+            return
     if no_input or not (sys.stdin.isatty() and sys.stdout.isatty()):
-        # Stay silent here; the InstallError later will print full instructions.
+        _dlog(f"skipping multiplexer prompt: no_input={no_input} stdin.isatty={sys.stdin.isatty()} stdout.isatty={sys.stdout.isatty()}")
+        # Stay silent here; the InstallError later will print full instructions
+        # on POSIX. Windows continues silently — single-terminal mode works.
         return
-    answer = _yes_default_prompt(
-        "We need tmux (a terminal multiplexer that lets teammates appear in their own panes). "
-        "Want me to try installing it for you?"
-    )
+    if sys.platform == "win32":
+        question = (
+            "We can install psmux (a terminal multiplexer that lets teammates appear in their own panes). "
+            "Without it, claude-anyteam still works but uses single-terminal mode. "
+            "Want me to try installing psmux for you?"
+        )
+    else:
+        question = (
+            "We need tmux (a terminal multiplexer that lets teammates appear in their own panes). "
+            "Want me to try installing it for you?"
+        )
+    answer = _yes_default_prompt(question)
     theme = get_theme()
+    multiplexer = _multiplexer_binary_for_platform()
     if answer is None or not answer:
         if answer is False:
-            print(f"{theme.symbols['info']} {theme.muted('Okay — skipping tmux auto-install. Manual steps will be shown below.')}", file=stream)
+            print(f"{theme.symbols['info']} {theme.muted(f'Okay — skipping {multiplexer} auto-install.')}", file=stream)
         return
     command = _multiplexer_install_command()
     if command is None:
-        print(f"{theme.symbols['warn']} {theme.warn('No package manager found')} {theme.muted('(brew / apt-get / dnf / pacman / apk) to install tmux automatically.')}", file=stream)
+        if sys.platform == "win32":
+            msg = "No package manager found (winget / scoop / choco) to install psmux automatically."
+        else:
+            msg = "No package manager found (brew / apt-get / dnf / pacman / apk) to install tmux automatically."
+        print(f"{theme.symbols['warn']} {theme.warn(msg)}", file=stream)
         return
     display, argv = command
     print(f"{theme.symbols['arrow']} {theme.heading('Running:')} {theme.accent(display)}", file=stream)
@@ -650,16 +729,16 @@ def _offer_multiplexer_install(*, no_input: bool, stream: TextIO) -> None:
         print(f"{theme.symbols['info']} {theme.muted('You may be prompted for your sudo password.')}", file=stream)
     ok, output = _run_install_command(argv)
     if ok:
-        print(f"{theme.symbols['success']} {theme.success('Installed tmux.')} {theme.muted('Continuing with claude-anyteam setup.')}", file=stream)
+        print(f"{theme.symbols['success']} {theme.success(f'Installed {multiplexer}.')} {theme.muted('Continuing with claude-anyteam setup.')}", file=stream)
         return
     body = [
-        f"{theme.symbols['error']} {theme.heading('I tried to install tmux, but it failed.')}",
+        f"{theme.symbols['error']} {theme.heading(f'I tried to install {multiplexer}, but it failed.')}",
         theme.muted("Raw installer output:"),
         *(f"  {theme.muted(line)}" for line in (output.splitlines() or ["No output captured."])),
         "",
         theme.muted("Falling through to manual instructions below."),
     ]
-    print(render_box(theme.danger("tmux auto-install failed"), body, "red", theme=theme), file=stream)
+    print(render_box(theme.danger(f"{multiplexer} auto-install failed"), body, "red", theme=theme), file=stream)
 
 
 def _offer_provider_dependency_installs(*, no_input: bool, stream: TextIO) -> None:
@@ -783,6 +862,12 @@ def _install_command(
     stream = out or sys.stdout
     if os.environ.get("CLAUDE_ANYTEAM_NPM_PARENT") != "1":
         print(_version_banner(), file=stream)
+    if debug_enabled():
+        _dlog(f"--- claude-anyteam install start ---")
+        _dlog(f"  npm-wrapper version (CLAUDE_ANYTEAM_NPM_VERSION): {os.environ.get('CLAUDE_ANYTEAM_NPM_VERSION', '<unset>')!r}")
+        _dlog(f"  python-tool version (importlib.metadata): {_python_tool_version()!r}")
+        _dlog(f"  argv: {sys.argv!r}")
+        _dlog_env(label="install-start")
     # Loud diagnostic when wrapper claims a newer version than the Python
     # tool actually installed — this used to silently mask v0.7.5 bug-fixes
     # because PyPI's index lagged npm publish and uv resolved an older wheel.
@@ -881,6 +966,9 @@ def main(argv: list[str] | None = None) -> int:
         command = argv[0]
         if command == "install":
             args = _parse_install_args(argv[1:])
+            if args.debug:
+                _debug_force_enable()
+                _dlog("--debug flag passed; CLAUDE_ANYTEAM_DEBUG=1 set in env")
             kwargs: dict[str, object] = {
                 "assume_yes": args.assume_yes,
                 "force_empty": args.force_empty,

--- a/src/claude_anyteam/installer.py
+++ b/src/claude_anyteam/installer.py
@@ -27,6 +27,7 @@ from pathlib import Path
 from typing import Any, Callable, Literal
 from urllib.parse import urlencode
 
+from ._debug import log as _dlog, log_subprocess as _dlog_sub, log_which as _dlog_which
 from ._theme import get_theme, render_box
 
 TEAMMATE_COMMAND_KEY = "CLAUDE_CODE_TEAMMATE_COMMAND"
@@ -1167,31 +1168,37 @@ def _delete_state(path: Path) -> bool:
 
 def _platform_name() -> str:
     raw = sys.platform
-    if raw.startswith("linux"):
-        return "linux"
-    if raw == "darwin":
-        return "darwin"
-    if raw in ("win32", "cygwin"):
-        return "windows"
-    return raw
+    name = "linux" if raw.startswith("linux") else "darwin" if raw == "darwin" else "windows" if raw in ("win32", "cygwin") else raw
+    _dlog(f"_platform_name: sys.platform={raw!r} -> {name!r}")
+    return name
 
 
 def _check_terminal_multiplexer() -> PrereqCheck:
-    """Checks PATH for tmux on Linux/macOS.
+    """Checks PATH for tmux on Linux/macOS, psmux on Windows.
 
-    Windows has no equivalent multiplexer requirement in the Python installer:
-    the install proceeds and Claude Code/plugin behavior decides how to spawn
-    panes there. This keeps Windows users from being blocked by a Unix-only
-    prerequisite.
+    On Windows we PROBE for psmux but don't BLOCK if it's missing — the
+    installer proceeds with single-terminal mode as a fallback. The
+    `_offer_multiplexer_install` prompt in cli.py invites the user to install
+    psmux for proper pane-based teammate visibility.
     """
     platform = _platform_name()
 
     if platform == "windows":
+        for name in ("psmux", "psmux.exe"):
+            found_path = shutil.which(name)
+            _dlog_which(name, found_path)
+            if found_path:
+                _dlog(f"multiplexer (psmux) found at {found_path}")
+                return PrereqCheck(found=True, binary="psmux", path=Path(found_path).resolve(), platform=platform)
+        # Windows is non-blocking: single-terminal mode works without a multiplexer.
+        _dlog("multiplexer (psmux) not found on Windows; reporting found=True (single-terminal mode)")
         return PrereqCheck(found=True, binary=None, path=None, platform=platform)
 
     for name in ("tmux",):
         found_path = shutil.which(name)
+        _dlog_which(name, found_path)
         if found_path:
+            _dlog(f"multiplexer (tmux) found at {found_path}")
             return PrereqCheck(
                 found=True,
                 binary=name,
@@ -1199,6 +1206,7 @@ def _check_terminal_multiplexer() -> PrereqCheck:
                 platform=platform,
             )
 
+    _dlog("multiplexer (tmux) NOT found; will block install on POSIX")
     return PrereqCheck(found=False, binary=None, path=None, platform=platform)
 
 
@@ -1288,7 +1296,9 @@ def _codex_meets_minimum(check: CodexCliCheck) -> bool | None:
 
 
 def _check_codex_cli() -> CodexCliCheck:
+    _dlog(f"_check_codex_cli: probing for {CODEX_CLI_BINARY!r}")
     found_path = shutil.which(CODEX_CLI_BINARY)
+    _dlog_which(CODEX_CLI_BINARY, found_path)
     if not found_path:
         return CodexCliCheck(
             found=False,
@@ -1596,7 +1606,9 @@ def _gemini_capabilities_from_help(help_text: str) -> dict[str, bool]:
 
 
 def _check_gemini_cli() -> GeminiCliCheck:
+    _dlog(f"_check_gemini_cli: probing for {GEMINI_CLI_BINARY!r}")
     found_path = shutil.which(GEMINI_CLI_BINARY)
+    _dlog_which(GEMINI_CLI_BINARY, found_path)
     if not found_path:
         return GeminiCliCheck(
             found=False,
@@ -1682,7 +1694,9 @@ def _resolve_kimi_binary() -> str | None:
 
 
 def _check_kimi_cli() -> KimiCliCheck:
+    _dlog(f"_check_kimi_cli: resolving via alias-aware probe (kimi, kimi-cli)")
     found_path = _resolve_kimi_binary()
+    _dlog(f"_check_kimi_cli resolved to: {found_path!r}")
     if not found_path:
         return KimiCliCheck(
             found=False,
@@ -1929,19 +1943,24 @@ def _collect_soft_diagnostics(
 
 
 def _register_claude_plugin() -> InstallError | None:
+    _dlog(f"_register_claude_plugin: probing for {CLAUDE_PLUGIN_BINARY!r}")
     claude = shutil.which(CLAUDE_PLUGIN_BINARY)
+    _dlog_which(CLAUDE_PLUGIN_BINARY, claude)
     if not claude:
         return _plugin_registration_error("`claude` was not found on PATH.")
 
+    argv = [claude, "plugin", "install", "JonathanRosado/claude-anyteam"]
     try:
         completed = subprocess.run(
-            [claude, "plugin", "install", "JonathanRosado/claude-anyteam"],
+            argv,
             capture_output=True,
             text=True,
             timeout=CLAUDE_PLUGIN_INSTALL_TIMEOUT_S,
             check=False,
         )
+        _dlog_sub(argv, completed, label="plugin-install")
     except (OSError, subprocess.SubprocessError) as exc:
+        _dlog(f"plugin install exception: {type(exc).__name__}: {exc}")
         return _plugin_registration_error(f"{type(exc).__name__}: {exc}")
 
     if completed.returncode == 0:

--- a/tests/test_npm_package.py
+++ b/tests/test_npm_package.py
@@ -12,7 +12,7 @@ def test_npm_package_metadata_matches_installer_contract() -> None:
     package = json.loads((NPM_DIR / 'package.json').read_text(encoding='utf-8'))
 
     assert package['name'] == 'claude-anyteam'
-    assert package['version'] == '0.7.6'
+    assert package['version'] == '0.7.7'
     assert package['bin']['claude-anyteam-setup'] == 'bin/setup.js'
     assert package['bin']['claude-anyteam'] == 'bin/setup.js'
     assert package['scripts']['postinstall'] == 'node bin/setup.js --postinstall'

--- a/uv.lock
+++ b/uv.lock
@@ -132,7 +132,7 @@ wheels = [
 
 [[package]]
 name = "claude-anyteam"
-version = "0.7.6"
+version = "0.7.7"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Why

You're right — 4 iterations is too many, and I've been guessing at Windows behavior I can't reproduce locally. This PR adds the diagnostic instrumentation needed to see what's actually happening on your machine, plus the Windows multiplexer (psmux) install path the previous releases were skipping.

## What you do once this ships

\`\`\`powershell
\$env:CLAUDE_ANYTEAM_DEBUG = '1'
npx --yes claude-anyteam
\`\`\`

(Or pass \`--debug\` as a CLI flag.)

Then paste the full stderr output. With the new logging, I'll see:
- Which Python tool version actually got installed
- The exact PATH at every checkpoint
- Whether \`shutil.which(\"kimi\")\` succeeded or returned None and why
- Every uv tool dir + every isfile probe in the resolver cascade
- The exit code + stdout/stderr of every subprocess (uv tool install, claude plugin install, etc.)
- Every env var the wrapper passed to the Python child

## Changes

### 1. \`CLAUDE_ANYTEAM_DEBUG=1\` env var + \`--debug\` CLI flag

Both npm wrapper and Python installer log to stderr with \`[debug] HH:MM:SS ...\` prefix. Passes through automatically: setting it on the npm wrapper propagates to the Python child via env.

Logged checkpoints:
- npm wrapper start: env snapshot, PATH (count + first 5 + last 3), platform/arch/node, isTTY for stdin/stdout/stderr
- Spawn of Python installer: full argv + env additions
- Python install start: same env snapshot, npm-claimed-version vs actually-installed-version, full argv
- Every \`_check_*_cli\` call: \`shutil.which\` result for codex/gemini/kimi/uv
- Platform detection: sys.platform → linux/darwin/windows mapping
- Multiplexer detection: tmux probe on POSIX, psmux probe on Windows
- \`_resolve_binary\` cascade: every alias try, every uv tool dir scan, every \`os.path.isfile\` probe with the result
- \`_uv_tool_bin_dirs\`: \`uv tool dir --bin\` + \`uv tool dir\` + every Scripts/bin candidate found
- \`_run_install_command\`: argv, exit code, stdout/stderr first 800 chars
- Plugin registration: probe + subprocess result

### 2. psmux on Windows

Previously the installer skipped multiplexer install entirely on Windows (\"single-terminal mode\" fallback). Now:
- \`_check_terminal_multiplexer\` actually probes for \`psmux\` on Windows
- \`_offer_multiplexer_install\` prompts on Windows when missing + TTY interactive
- Install attempts via \`winget install --id psmux.psmux\` → fallback \`scoop install psmux\` → fallback \`choco install psmux\`
- Single-terminal mode remains the documented fallback if user declines or no PM available — install still proceeds

### 3. Banner shows \`(debug mode)\` indicator when active

So you can confirm the flag took effect just from the banner line.

## Tests

- 129 pytest pass
- 26 Node tests pass
- Smoke test confirms debug logs render correctly

## Validation path

Once you merge, auto-release ships v0.7.7. Run the debug-mode invocation above and paste the stderr — the next iteration will be data-driven, not another round of guessing.