### PR TITLE
v0.7.10 — action-required sign-in CTA at bottom of installer

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-anyteam",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "description": "Beautiful zero-friction installer for claude-anyteam in Claude Code.",
   "type": "module",
   "bin": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "claude-anyteam"
-version = "0.7.9"
+version = "0.7.10"
 description = "Bring Codex, Gemini, and Kimi CLI powered teammates into Claude Code with multi-backend routing."
 requires-python = ">=3.12"
 license = "MIT"

--- a/src/claude_anyteam/installer.py
+++ b/src/claude_anyteam/installer.py
@@ -2932,6 +2932,54 @@ def _format_provider_walkthroughs(
     return "\n\n".join(blocks)
 
 
+def _signin_command(provider_key: str) -> tuple[str, str | None]:
+    """Returns (command, optional alternative hint) for the sign-in step."""
+    if provider_key == "codex":
+        return (f"{CODEX_CLI_BINARY}", "opens an OAuth flow on first run")
+    if provider_key == "gemini":
+        return (f"{GEMINI_CLI_BINARY}", "or set GEMINI_API_KEY / configure Vertex")
+    if provider_key == "kimi":
+        return (f"{KIMI_CLI_BINARY} login", None)
+    return (provider_key, None)
+
+
+def _format_signin_cta(
+    statuses: tuple[ProviderStatus, ...] | list[ProviderStatus],
+) -> str:
+    """Big, prominent box at the very end of install output telling the user
+    EXACTLY which sign-in commands to run for installed-but-not-signed-in
+    providers. The walkthroughs above already mention this, but they're
+    buried mid-output. This is the action-required-before-you-can-use-it CTA.
+    """
+    pending = [s for s in statuses if s.state == "NEEDS_SIGNIN"]
+    if not pending:
+        return ""
+    theme = get_theme()
+    if theme.color:
+        body: list[str] = []
+        for idx, status in enumerate(pending):
+            cmd, hint = _signin_command(status.provider_key)
+            if idx > 0:
+                body.append("")
+            body.append(f"{theme.symbols['info']} {theme.heading(status.display_name)} {theme.muted('— signed in: no')}")
+            body.append(f"  {theme.symbols['arrow']} {theme.muted('Run:')} {theme.accent(cmd)}")
+            if hint:
+                body.append(f"    {theme.muted(f'({hint})')}")
+        body.append("")
+        body.append(f"{theme.symbols['warn']} {theme.warn('Then restart Claude Code')} {theme.muted('so the new sign-in state is picked up.')}")
+        return render_box(theme.heading("Action required — sign in to start using teammates"), body, "magenta", theme=theme)
+    # Plain-text fallback for tests / piped output.
+    lines = ["Action required — sign in to start using teammates:", ""]
+    for status in pending:
+        cmd, hint = _signin_command(status.provider_key)
+        lines.append(f"  {status.display_name}:")
+        suffix = f"  ({hint})" if hint else ""
+        lines.append(f"    Run: {cmd}{suffix}")
+    lines.append("")
+    lines.append("Then restart Claude Code so the new sign-in state is picked up.")
+    return "\n".join(lines)
+
+
 def _format_no_provider_refusal_message() -> str:
     return (
         "Refusing to install — no provider is ready.\n"
@@ -3113,6 +3161,12 @@ def format_install_message(result: InstallResult, *, include_provider_status: bo
         lines.append(render_box(theme.success("Setup applied"), themed_lines, "green", theme=theme))
     else:
         lines.append("\n".join(receipt_lines))
+
+    # Final CTA: if any installed providers still need sign-in, render a big
+    # action-required box AT THE BOTTOM so the user can't miss the next step.
+    cta = _format_signin_cta((codex_status, gemini_status, kimi_status))
+    if cta:
+        lines.append(cta)
     return "\n\n".join(lines)
 
 

--- a/tests/test_npm_package.py
+++ b/tests/test_npm_package.py
@@ -12,7 +12,7 @@ def test_npm_package_metadata_matches_installer_contract() -> None:
     package = json.loads((NPM_DIR / 'package.json').read_text(encoding='utf-8'))
 
     assert package['name'] == 'claude-anyteam'
-    assert package['version'] == '0.7.9'
+    assert package['version'] == '0.7.10'
     assert package['bin']['claude-anyteam-setup'] == 'bin/setup.js'
     assert package['bin']['claude-anyteam'] == 'bin/setup.js'
     assert package['scripts']['postinstall'] == 'node bin/setup.js --postinstall'

--- a/uv.lock
+++ b/uv.lock
@@ -132,7 +132,7 @@ wheels = [
 
 [[package]]
 name = "claude-anyteam"
-version = "0.7.9"
+version = "0.7.10"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Why

After v0.7.9 made everything actually work end-to-end, the only thing left for the user is to run the per-provider sign-in commands. The walkthrough lines (\`Gemini CLI: 1. Sign in: gemini ...\`) exist mid-output but are easy to miss between the provider table and the Setup Applied box.

User asked for a big visible CTA at the very bottom so it can't be missed.

## Change

New \`_format_signin_cta(statuses)\` rendered at the end of \`format_install_message\`, AFTER the green \"Setup applied\" box. Magenta-bordered box titled \"Action required — sign in to start using teammates\" with one block per provider in \`NEEDS_SIGNIN\` state:

\`\`\`
╭─ Action required — sign in to start using teammates ─╮
│ ● Gemini CLI — signed in: no                         │
│   → Run: gemini                                      │
│     (or set GEMINI_API_KEY / configure Vertex)       │
│                                                      │
│ ● Kimi CLI — signed in: no                           │
│   → Run: kimi login                                  │
│                                                      │
│ ▲ Then restart Claude Code so the new sign-in        │
│   state is picked up.                                │
╰──────────────────────────────────────────────────────╯
\`\`\`

Empty / omitted entirely when all providers are READY (no noise for users already set up). Plain-text fallback for non-color terminals + tests.

## Tests

- 129 pytest pass
- 26 Node tests pass
- Smoke render confirms the box displays correctly with magenta border + cyan accents