### PR TITLE
fix(#32, #40 Phase 1): codex bootstrap visibility, app-server initialize budget + typed events, process-group teardown, task_blocked drift warn

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,15 @@ dependencies = [
     # `claude_anyteam.wrapper_server` and pinned to match the team-protocol
     # implementation's runtime expectations.
     "fastmcp==3.0.0b1",
+    # Transitive of fastmcp / mcp / httpx-sse. Pin below 1.0 explicitly:
+    # uv's resolver promoted `httpx==1.0.dev3` into clean tool-venv installs
+    # (the dev release satisfies `>=0.27.1`/`>=0.28.1`) and that release
+    # removed `httpx.TransportError`, which `httpx-sse` imports. Result:
+    # `from fastmcp import FastMCP` raised `AttributeError` at import time,
+    # the codex spawn shim crashed inside its tmux pane, and no registration
+    # event ever fired — the silent-spawn failure observed in #32. Hold the
+    # pin until fastmcp / httpx-sse drop their httpx-1.0 incompatibility.
+    "httpx>=0.28,<1.0",
     # Used by `claude_teams` for the file-based mailbox / config locking
     # that the team protocol relies on.
     "filelock==3.16",

--- a/src/claude_anyteam/app_server.py
+++ b/src/claude_anyteam/app_server.py
@@ -27,6 +27,19 @@ class AppServerClient(JsonRpcStdioClient):
             env=env,
             log_prefix="app_server",
             stderr_log_prefix="app_server.stderr",
+            # Put the Codex app-server (and any helper subprocesses it forks
+            # for auth refresh / model I/O / network handshake) in its own
+            # POSIX session so that ``close()`` can SIGTERM the entire process
+            # group, not just the leader. Without this, helper children
+            # outlive the wrapper's ``client.close()`` and the next per-turn
+            # ``AppServerClient`` cold start can collide with their open fds /
+            # sockets / cache locks — the long-lived-wrapper
+            # "second-or-later cold-start hangs at initialize for 600s"
+            # symptom in #40. Mirrors the convention the gemini ACP transport
+            # already uses (``backends/gemini/acp.py``:
+            # ``client.terminate_process_group(...)``).
+            start_new_session=True,
+            terminate_process_group=True,
         )
         self._error_cls = AppServerError
         self.last_thread_result: dict[str, Any] | None = None
@@ -139,12 +152,30 @@ class AppServerClient(JsonRpcStdioClient):
 
     # ---- helpers for well-known methods -----------------------------------
 
-    def initialize(self, client_info: dict[str, Any] | None = None) -> Any:
+    def initialize(
+        self,
+        client_info: dict[str, Any] | None = None,
+        *,
+        timeout: float | None = None,
+    ) -> Any:
+        """Send the JSON-RPC ``initialize`` handshake.
+
+        ``timeout`` overrides ``request()``'s 600s default; the Codex App
+        Server initialize handshake should complete in seconds, not
+        minutes — the only successful empirical sample we have is ~17s on
+        a parking-ack prompt (issue #40 thread). 600s as the silent
+        default made a hung handshake indistinguishable from "agent is
+        thinking hard." Callers should pass an explicit budget (the
+        adapter loop reads ``CLAUDE_ANYTEAM_APP_SERVER_INITIALIZE_TIMEOUT_S``,
+        default 90s).
+        """
         params = {
             "clientInfo": client_info
             or {"name": "claude-anyteam-adapter", "version": "0.1.0"},
         }
-        return self.request("initialize", params)
+        if timeout is None:
+            return self.request("initialize", params)
+        return self.request("initialize", params, timeout=timeout)
 
     def thread_start(
         self,

--- a/src/claude_anyteam/codex.py
+++ b/src/claude_anyteam/codex.py
@@ -36,6 +36,8 @@ from typing import Any, Callable
 
 from . import logger
 from .env import (
+    APP_SERVER_INITIALIZE_PROGRESS_INTERVAL_ENV,
+    APP_SERVER_INITIALIZE_TIMEOUT_ENV,
     CWD_ENV,
     DUMP_EVENTS_ENV,
     LEGACY_CWD_ENV,
@@ -754,6 +756,225 @@ def run(
 # can inject additional input into an in-flight turn when a mid-task inbox
 # message arrives. See `docs/v7-architecture.md` §4 (Option Y) and the
 # v7.1 task spec.
+
+
+_DEFAULT_INITIALIZE_TIMEOUT_S = 90.0
+_DEFAULT_INITIALIZE_PROGRESS_INTERVAL_S = 30.0
+
+
+def _read_float_env(name: str, default: float, *, allow_zero: bool = False) -> float:
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        return default
+    if allow_zero:
+        return max(0.0, value)
+    return max(0.001, value)
+
+
+def _read_proc_cpu_pct(pid: int) -> float | None:
+    """Best-effort CPU% sample from ``/proc/<pid>/stat`` (Linux only).
+
+    Returns the cumulative ``utime + stime`` ratio over the process's wall
+    time since fork — coarser than ``ps``'s short-window sample but
+    requires no extra threads or sampling intervals. Used in
+    ``app_server_initialize_progress`` payloads so the lead can see "this
+    second-spawn is wedged at 100% CPU" without running ``top``. Silent
+    on non-Linux (returns None) — the lead's UI just omits the field.
+    """
+    try:
+        with open(f"/proc/{pid}/stat", "r", encoding="utf-8") as fh:
+            stat = fh.read()
+    except (FileNotFoundError, PermissionError, OSError):
+        return None
+    # Field order: pid (comm) state ppid pgrp session tty_nr tpgid flags
+    # minflt cminflt majflt cmajflt utime stime cutime cstime priority
+    # nice num_threads ... starttime ...
+    # `comm` may contain spaces inside parentheses, so split on the
+    # closing paren rather than whitespace.
+    try:
+        end_comm = stat.rindex(") ")
+        rest = stat[end_comm + 2 :].split()
+        utime = int(rest[11])  # 14 - 3
+        stime = int(rest[12])  # 15 - 3
+        starttime = int(rest[19])  # 22 - 3
+    except (ValueError, IndexError):
+        return None
+    try:
+        with open("/proc/uptime", "r", encoding="utf-8") as fh:
+            uptime = float(fh.read().split()[0])
+    except (FileNotFoundError, OSError, ValueError, IndexError):
+        return None
+    try:
+        clock_ticks = float(os.sysconf("SC_CLK_TCK"))
+    except (AttributeError, OSError, ValueError):
+        clock_ticks = 100.0
+    elapsed_s = uptime - (starttime / clock_ticks)
+    if elapsed_s <= 0:
+        return None
+    cpu_s = (utime + stime) / clock_ticks
+    return min(100.0 * 8, (cpu_s / elapsed_s) * 100.0)
+
+
+def _initialize_with_progress_events(
+    client: "Any",
+    *,
+    emit_visibility: Callable[..., VisibilityEvent],
+    prompt_byte_size: int,
+) -> Any:
+    """Run JSON-RPC ``initialize`` against the App Server with timing,
+    progress events, and a bounded budget.
+
+    #40 Phase 1 deliverables, all bundled here so the App Server entry
+    path has one structured handshake surface:
+
+    * ``timeout`` defaults to 90s (override via
+      ``CLAUDE_ANYTEAM_APP_SERVER_INITIALIZE_TIMEOUT_S``). The previous
+      600s default was the only signal a hung initialize was hung at all
+      — see #40 issue thread, "10-minute silence is indistinguishable
+      from 'agent is genuinely thinking hard.'"
+    * On success, emits ``app_server_initialize_completed`` with
+      ``elapsed_ms`` and ``prompt_byte_size``. This is the success-path
+      instrumentation the steward asked for so we can revisit the 90s
+      default with real data instead of the single 17s anecdote.
+    * While waiting, emits ``app_server_initialize_progress`` events at
+      ``CLAUDE_ANYTEAM_APP_SERVER_INITIALIZE_PROGRESS_INTERVAL_S`` (default
+      30s; set 0 to disable). Each carries ``attempt``, ``elapsed_s``,
+      ``last_observed_pid``, and (Linux only) ``last_observed_cpu_pct``.
+
+    On timeout: re-raises the underlying ``AppServerError`` so the
+    surrounding ``try`` block in ``app_server_invoke`` records the
+    failure via the existing `turn_failed` path. The error message is
+    preserved so loop-side handlers that key on
+    ``"did not respond to initialize"`` continue to work.
+
+    ``prompt_byte_size`` source choice: callers pass
+    ``len(task_prompt.encode('utf-8'))`` where ``task_prompt`` is the
+    ``developer_instructions`` block we'll send to Codex on
+    ``thread/start``. This is the user-supplied content that contributes
+    to the prompt-side preprocessing the App Server may do before
+    replying to ``initialize``. We deliberately do NOT include the
+    base instructions / system prompt boilerplate in the byte-size: that
+    payload is constant across turns, and the variable that
+    distinguishes a fast first-cold-start from a slow one in the issue
+    thread is the user's task brief size. See product-steward's #40
+    Phase 1 brief, point 4.
+    """
+    import threading
+
+    timeout_s = _read_float_env(
+        APP_SERVER_INITIALIZE_TIMEOUT_ENV,
+        _DEFAULT_INITIALIZE_TIMEOUT_S,
+    )
+    progress_interval_s = _read_float_env(
+        APP_SERVER_INITIALIZE_PROGRESS_INTERVAL_ENV,
+        _DEFAULT_INITIALIZE_PROGRESS_INTERVAL_S,
+        allow_zero=True,
+    )
+
+    started_at = time.monotonic()
+    result_holder: dict[str, Any] = {}
+    error_holder: dict[str, BaseException] = {}
+
+    def _worker() -> None:
+        try:
+            result_holder["result"] = client.initialize(timeout=timeout_s)
+        except BaseException as exc:  # noqa: BLE001 — re-raised on main
+            error_holder["error"] = exc
+
+    worker = threading.Thread(
+        target=_worker,
+        name="app_server-initialize",
+        daemon=True,
+    )
+    worker.start()
+
+    attempt = 0
+    while True:
+        wait_s = (
+            min(progress_interval_s, max(0.05, timeout_s - (time.monotonic() - started_at)))
+            if progress_interval_s > 0
+            else max(0.05, timeout_s - (time.monotonic() - started_at))
+        )
+        worker.join(timeout=wait_s)
+        if not worker.is_alive():
+            break
+        elapsed_s = time.monotonic() - started_at
+        if elapsed_s >= timeout_s:
+            # The underlying request() timeout will fire on its own; let
+            # the worker observe it and raise. We just stop emitting
+            # progress and fall through to the join below.
+            break
+        if progress_interval_s <= 0:
+            continue
+        attempt += 1
+        pid = client.pid
+        cpu_pct = _read_proc_cpu_pct(pid) if isinstance(pid, int) else None
+        progress_payload: dict[str, Any] = {
+            "attempt": attempt,
+            "elapsed_s": round(elapsed_s, 2),
+            "timeout_s": timeout_s,
+            "progress_interval_s": progress_interval_s,
+            "prompt_byte_size": prompt_byte_size,
+            "last_observed_pid": pid,
+        }
+        if cpu_pct is not None:
+            progress_payload["last_observed_cpu_pct"] = round(cpu_pct, 1)
+        try:
+            emit_visibility(
+                kind="app_server_initialize_progress",
+                severity="warn",
+                summary=(
+                    f"Codex App Server initialize still pending after "
+                    f"{int(elapsed_s)}s (attempt {attempt})"
+                ),
+                visibility={
+                    "mailbox": False,
+                    "task_state": False,
+                    "event_log": True,
+                    "stderr": True,
+                },
+                payload=progress_payload,
+            )
+        except Exception as e:
+            logger.debug(
+                "app_server.initialize_progress_emit_failed",
+                error=str(e),
+            )
+
+    worker.join()
+    elapsed_ms = int((time.monotonic() - started_at) * 1000)
+
+    if "error" in error_holder:
+        raise error_holder["error"]
+
+    try:
+        emit_visibility(
+            kind="app_server_initialize_completed",
+            severity="info",
+            summary=f"Codex App Server initialize completed in {elapsed_ms}ms",
+            visibility={
+                "mailbox": False,
+                "task_state": False,
+                "event_log": True,
+                "stderr": True,
+            },
+            payload={
+                "elapsed_ms": elapsed_ms,
+                "prompt_byte_size": prompt_byte_size,
+                "timeout_s": timeout_s,
+            },
+        )
+    except Exception as e:
+        logger.debug(
+            "app_server.initialize_completed_emit_failed",
+            error=str(e),
+        )
+
+    return result_holder.get("result")
 
 
 def _start_or_fork_thread(
@@ -1481,7 +1702,11 @@ def app_server_invoke(
 
     try:
         client.start()
-        client.initialize()
+        _initialize_with_progress_events(
+            client,
+            emit_visibility=_emit_visibility_event,
+            prompt_byte_size=len(task_prompt.encode("utf-8")),
+        )
 
         thread_id = _start_or_fork_thread(
             client,

--- a/src/claude_anyteam/diagnostics.py
+++ b/src/claude_anyteam/diagnostics.py
@@ -117,6 +117,7 @@ def record_incident(
 ERROR_CLASSES: tuple[str, ...] = (
     "subprocess_crash",         # the backend process didn't return a result at all
     "turn_timeout",             # backend reported its own timeout (e.g. App Server 900s)
+    "app_server_initialize_timeout",  # JSON-RPC `initialize` budget exceeded (#40 Phase 1)
     "schema_validation_failed", # final response didn't match the configured schema
     "mcp_send_message_unavailable",  # wrapper MCP allowlist gap (B2 lifecycle bug)
     "subprocess_nonzero_exit",  # backend exited non-zero with no clearer signal
@@ -138,6 +139,10 @@ def classify_failure(result: Any) -> str:
     if result is None:
         return "subprocess_crash"
     err = (getattr(result, "error", "") or "").lower()
+    # Check more specific patterns BEFORE generic "timeout" so initialize
+    # timeouts are classified into their dedicated bucket (#40 Phase 1).
+    if "did not respond to initialize" in err:
+        return "app_server_initialize_timeout"
     if "timeout" in err or "did not complete within" in err:
         return "turn_timeout"
     if "schema" in err and "valid" in err:
@@ -155,7 +160,20 @@ def fallback_message(*, backend: str, incident_id: str, error_class: str) -> str
     The shape is the same across backends so the lead can recognize it at
     a glance regardless of which teammate emitted it. Keep it short — this
     text lands in chat, not a log viewer.
+
+    #40 Phase 1: ``app_server_initialize_timeout`` gets a concise pointer
+    rather than the full apologetic preamble. The typed
+    ``visibility_degraded`` event the prose-bound emitter pairs with
+    carries the structured detail; prose stays minimal. See product
+    steward's #40 Phase 1 brief, Gap 2.
     """
+    if error_class == "app_server_initialize_timeout":
+        return (
+            f"App Server initialize timed out (incident_id={incident_id}). "
+            f"See `claude-anyteam diagnose --incident {incident_id}` for "
+            f"detail; the typed visibility_degraded event has structured "
+            f"context for the lead's event log."
+        )
     return (
         f"I received your message but couldn't generate a reply "
         f"(adapter={backend}, error={error_class}, incident={incident_id}). "

--- a/src/claude_anyteam/env.py
+++ b/src/claude_anyteam/env.py
@@ -45,6 +45,21 @@ LEGACY_NON_PROGRESS_WARN_ENV = "CODEX_TEAMMATE_NON_PROGRESS_WARN_S"
 NON_PROGRESS_INTERRUPT_ENV = "CLAUDE_ANYTEAM_NON_PROGRESS_INTERRUPT_S"
 LEGACY_NON_PROGRESS_INTERRUPT_ENV = "CODEX_TEAMMATE_NON_PROGRESS_INTERRUPT_S"
 
+# Codex App Server JSON-RPC ``initialize`` budget (#40 Phase 1).
+# Default 90s — chosen because the only successful empirical sample we
+# have (codex-reviewer turn 1, parking-ack prompt, ~17s) is well under
+# 90s. Override via env when a legitimate first-cold-start on a complex
+# prompt needs longer; the new ``app_server_initialize_completed`` event
+# records ``elapsed_ms`` and ``prompt_byte_size`` per success so we can
+# revisit the default with data, not vibes.
+APP_SERVER_INITIALIZE_TIMEOUT_ENV = "CLAUDE_ANYTEAM_APP_SERVER_INITIALIZE_TIMEOUT_S"
+# Cadence (in seconds) for ``app_server_initialize_progress`` typed
+# events emitted while waiting on JSON-RPC ``initialize`` (#40 Phase 1).
+# Default 30s. Set to 0 to disable progress emission entirely.
+APP_SERVER_INITIALIZE_PROGRESS_INTERVAL_ENV = (
+    "CLAUDE_ANYTEAM_APP_SERVER_INITIALIZE_PROGRESS_INTERVAL_S"
+)
+
 LOG_ENV = "CLAUDE_ANYTEAM_LOG"
 LEGACY_LOG_ENV = "CODEX_TEAMMATE_LOG"
 

--- a/src/claude_anyteam/loop.py
+++ b/src/claude_anyteam/loop.py
@@ -158,38 +158,89 @@ def _backend_metadata(settings: Settings) -> BackendMetadata:
 
 
 def run(settings: Settings) -> int:
-    """Run the adapter's main loop. Returns a process exit code."""
-    codex_mod.feature_test(
-        settings.codex_binary,
-        mcp_probe=True,
-        team=settings.team_name,
-        agent_name=settings.agent_name,
-    )
-    register(settings, _backend_metadata(settings))
+    """Run the adapter's main loop. Returns a process exit code.
 
-    state = LoopState(settings=settings)
-    state.self_capability_manifest = pio.read_agent_manifest(
-        settings.team_name,
-        settings.agent_name,
-    )
-    state.peer_manifest_cache = CapabilityManifestCache(
-        settings.team_name,
-        self_name=settings.agent_name,
-    )
-    state.peer_manifest_cache.load_startup()
-
-    def _sig_handler(signum: int, _frame: Any) -> None:
-        logger.warn("signal.received", signum=signum)
-        state.shutdown_requested = True
-
-    signal.signal(signal.SIGINT, _sig_handler)
-    signal.signal(signal.SIGTERM, _sig_handler)
-
+    Bootstrap (``feature_test``, ``register``, manifest load, signal setup)
+    runs inside the same try/except as ``_main_loop`` so a crash before the
+    first inbox poll is surfaced to the lead the same way native-Claude and
+    Gemini/Kimi cold-start crashes are: a structured ``visibility_degraded``
+    envelope to the lead mailbox + event log, plus a ``record_incident``
+    diagnostic. Without this, codex-* spawn-bootstrap failures (e.g. the v0.5
+    httpx-version-mismatch that broke ``from fastmcp import FastMCP``) exit
+    silently to a tmux-pane stderr the lead may not be reading — see issue
+    #32. Mirrors the pattern that Gemini's ``backends/gemini/loop.py:run`` and
+    Kimi's ``backends/kimi/loop.py:run`` already use.
+    """
+    state: LoopState | None = None
     exit_code = 0
+    startup_phase = "feature_test"
+    startup_complete = False
     try:
+        codex_mod.feature_test(
+            settings.codex_binary,
+            mcp_probe=True,
+            team=settings.team_name,
+            agent_name=settings.agent_name,
+        )
+        startup_phase = "registration"
+        register(settings, _backend_metadata(settings))
+
+        startup_phase = "capability_manifest_load"
+        state = LoopState(settings=settings)
+        state.self_capability_manifest = pio.read_agent_manifest(
+            settings.team_name,
+            settings.agent_name,
+        )
+        state.peer_manifest_cache = CapabilityManifestCache(
+            settings.team_name,
+            self_name=settings.agent_name,
+        )
+        state.peer_manifest_cache.load_startup()
+
+        def _sig_handler(signum: int, _frame: Any) -> None:
+            logger.warn("signal.received", signum=signum)
+            assert state is not None
+            state.shutdown_requested = True
+
+        startup_phase = "signal_setup"
+        signal.signal(signal.SIGINT, _sig_handler)
+        signal.signal(signal.SIGTERM, _sig_handler)
+
+        startup_complete = True
         _main_loop(state)
     except Exception as e:
-        logger.error("loop.crash", error=str(e))
+        if startup_complete:
+            logger.error("loop.crash", error=str(e))
+            error_class = "adapter_crash"
+        else:
+            logger.error(
+                "loop.startup_crash",
+                phase=startup_phase,
+                error=str(e),
+            )
+            error_class = "adapter_startup_crash"
+            # Startup failures happen before the first inbox poll, so fan out
+            # an envelope directly. Without this the lead sees a teammate that
+            # never registers — indistinguishable from "still booting" for the
+            # lifetime of the team. (#32 visibility-parity gap.)
+            try:
+                pio.emit_adapter_startup_crash(
+                    team=settings.team_name,
+                    agent=settings.agent_name,
+                    backend="codex",
+                    phase=startup_phase,
+                    error=e,
+                    payload={
+                        "codex_binary": settings.codex_binary,
+                        "cwd": str(settings.cwd),
+                        "app_server": bool(getattr(settings, "app_server", False)),
+                    },
+                )
+            except Exception as emit_exc:
+                logger.debug(
+                    "loop.startup.visibility_emit_failed",
+                    error=str(emit_exc),
+                )
         # Persist a structured incident so the lead can find this via
         # `claude-anyteam diagnose`. Without this the only crash signal
         # is stderr in a tmux pane the lead may not be reading.
@@ -199,7 +250,7 @@ def run(settings: Settings) -> int:
                 team=settings.team_name,
                 agent=settings.agent_name,
                 backend="codex",
-                error_class="adapter_crash",
+                error_class=error_class,
                 summary=str(e),
             )
         except Exception:
@@ -213,13 +264,13 @@ def run(settings: Settings) -> int:
         # and returning — so SIGTERM exits cleanly. Only uncaught exceptions
         # (loop.crash) skip deregistration and leave a zombie entry for the
         # lead to inspect.
-        if state.approved_shutdown:
+        if state is not None and state.approved_shutdown:
             deregister(settings)
             logger.info("loop.deregistered", name=settings.agent_name)
         else:
             logger.warn(
                 "loop.exit_without_deregister",
-                in_flight_task=state.in_flight_task,
+                in_flight_task=(state.in_flight_task if state is not None else None),
             )
     return exit_code
 
@@ -501,6 +552,17 @@ def _prose_fallback_reply(
     the incident_id embedded so the lead can run
     ``claude-anyteam diagnose --incident <id>`` to recover details without
     raw error strings leaking into chat.
+
+    #40 Phase 1 — Gap 2 (prose-bound initialize timeout): when the
+    failure is specifically the App Server JSON-RPC ``initialize``
+    timeout (the most common high-cost failure surfaced in the issue
+    thread), ALSO emit a typed ``visibility_degraded`` envelope to the
+    lead with ``surface="app_server_initialize_timeout"`` and
+    ``phase="prose_bound"``. The prose response stays as the courtesy
+    completion (the sender's turn needs *some* reply), but it's
+    rewritten to be a thin pointer at the typed event rather than an
+    apology in lieu of structured detail. See product-steward's #40
+    Phase 1 brief, Gap 2.
     """
     from . import diagnostics  # local import keeps loop.py import graph thin
     s = state.settings
@@ -520,6 +582,29 @@ def _prose_fallback_reply(
             "error": (result.error if result is not None else None),
         },
     )
+    if error_class == "app_server_initialize_timeout":
+        # Pair the prose pointer with a typed event the lead's event log
+        # surfaces immediately. The shutdown_request flag distinguishes
+        # no-op shutdown burns (the user's #40 evidence: even 600s on
+        # a {"type":"shutdown_request"}) from work-turn timeouts so the
+        # lead can filter on `shutdown_request: true` for the worst-UX
+        # variant.
+        try:
+            pio.emit_initialize_timeout_visibility_degraded(
+                team=s.team_name,
+                agent=s.agent_name,
+                backend="codex",
+                phase="prose_bound",
+                incident_id=incident_id,
+                sender=sender,
+                shutdown_request=state.shutdown_requested,
+                error=(result.error if result is not None else None),
+            )
+        except Exception as e:
+            logger.debug(
+                "prose.initialize_timeout_visibility_emit_failed",
+                error=str(e),
+            )
     return diagnostics.fallback_message(
         backend="codex",
         incident_id=incident_id,
@@ -1267,11 +1352,19 @@ def _execute_task(state: LoopState, task) -> None:
             exit_code=result.exit_code,
             error=result.error,
         )
-        _mark_blocked(
-            state,
-            task,
-            reason=(result.error or f"codex exited {result.exit_code} with no structured result"),
+        # #40 Phase 1: when the failure is specifically the App Server
+        # JSON-RPC ``initialize`` timeout, route to a stable
+        # machine-readable reason token so the lead's task-state view
+        # can grep ``task_blocked.reason == "app_server_initialize_timeout"``
+        # (or ``"app_server_shutdown_timeout"`` if a shutdown is in
+        # flight) instead of parsing a per-incident error string.
+        # Replaces the ad-hoc prose_reply fallback the wrapper used to
+        # emit. Both tokens live in ``messages.KNOWN_TASK_BLOCKED_REASONS``.
+        reason = _classify_task_block_reason(
+            result,
+            shutdown_requested=state.shutdown_requested,
         )
+        _mark_blocked(state, task, reason=reason)
         state.in_flight_task = None
         return
 
@@ -1698,6 +1791,38 @@ def _execute_task_app_server(state: LoopState, task, prompt: str):
                 error=str(e),
             )
     return result
+
+
+def _classify_task_block_reason(result: Any, *, shutdown_requested: bool = False) -> str:
+    """Map a failed Codex result to a stable ``task_blocked.reason`` token.
+
+    Today the wrapper used the raw error string as the reason, which made
+    lead-side filters key on substrings like ``"did not respond to
+    initialize"``. #40 Phase 1 surfaces a stable machine-readable token
+    for the most common high-cost failures so lead-side automation can
+    branch cleanly:
+
+    - ``"app_server_shutdown_timeout"`` — JSON-RPC ``initialize`` did
+      not respond, AND the adapter has an in-flight shutdown request.
+      The user's #40 thread documented "even shutdown turns hang for
+      600s" — distinct discriminator so the lead can filter no-op
+      shutdown burns separately from work-turn timeouts.
+    - ``"app_server_initialize_timeout"`` — JSON-RPC ``initialize`` did
+      not respond within the configured budget on a regular turn.
+    - Falls back to the raw error string (preserves prior behavior for
+      the long tail of failures we haven't classified yet).
+
+    Both new tokens live in
+    ``claude_anyteam.messages.KNOWN_TASK_BLOCKED_REASONS`` so the
+    wrapper-MCP validator recognizes them as registered.
+    """
+    err = (getattr(result, "error", "") or "")
+    err_l = err.lower()
+    if "did not respond to initialize" in err_l:
+        if shutdown_requested:
+            return "app_server_shutdown_timeout"
+        return "app_server_initialize_timeout"
+    return err or f"codex exited {getattr(result, 'exit_code', '?')} with no structured result"
 
 
 def _mark_blocked(state: LoopState, task, reason: str) -> None:

--- a/src/claude_anyteam/messages.py
+++ b/src/claude_anyteam/messages.py
@@ -12,6 +12,7 @@ conform exactly.
 
 from __future__ import annotations
 
+import re
 from datetime import datetime, timezone
 from typing import Any, Literal
 
@@ -254,6 +255,58 @@ class TaskBlockedOut(_Base):
     timestamp: str = Field(default_factory=now_iso)
 
 
+# #40 Phase 1 — discriminated-reason registry (graduated enforcement).
+#
+# ``task_blocked.reason`` is an open ``str`` field for backward compat
+# with existing free-form values like ``"codex invocation crashed: ..."``
+# or ``"plan generation failed twice ..."``. New machine-readable tokens
+# get registered here so peers can query/filter by stable discriminator
+# instead of grepping prose substrates. The wrapper-MCP ``send_message``
+# tool emits a ``visibility_degraded`` warn for token-shaped reasons that
+# are NOT in this registry — surfaces drift without blocking delivery.
+#
+# Adding a new typed token? Add it here AND ensure the emit-site is
+# tested. Free-form prose reasons (with whitespace / mixed case) bypass
+# the validator entirely — they are still legal but not recommended.
+#
+# Per ``feedback_graduated_enforcement_ladder``: rung 1 (declare) +
+# rung 2 (suggest via warn). Future PR can promote to rung 3 (reject)
+# once we've verified all production emit-sites use registered tokens.
+KNOWN_TASK_BLOCKED_REASONS: frozenset[str] = frozenset(
+    {
+        # #40 Phase 1: JSON-RPC ``initialize`` budget exceeded during a
+        # turn invocation. Stable token replaces the prior raw error
+        # string ``"app_server error: did not respond to initialize ..."``.
+        "app_server_initialize_timeout",
+        # #40 Phase 1: ``initialize`` budget exceeded specifically while
+        # the adapter was honoring an in-flight ``shutdown_request``. The
+        # discriminator distinction lets the lead surface a no-op
+        # shutdown burning the budget vs a work-turn timeout uniformly
+        # in their dashboard, but with separate filters.
+        "app_server_shutdown_timeout",
+    }
+)
+
+
+# Token shape for the registry's gate: snake_case, lowercase ASCII +
+# digits + underscores, starting with a letter. Matches what we expect
+# for stable machine-readable reason values; everything else (prose with
+# spaces, mixed case, JSON, traceback dumps) bypasses the gate.
+_TOKEN_SHAPED_REASON_RE = re.compile(r"^[a-z][a-z0-9_]+$")
+
+
+def is_token_shaped_reason(reason: str) -> bool:
+    """Return True if ``reason`` looks like a stable machine-readable token.
+
+    The wrapper-MCP validator only checks the registry for token-shaped
+    values; free-form prose reasons (which have whitespace or punctuation
+    or mixed case) pass through silently. This is the §1-respecting
+    pragmatic shape: structural tokens are policed, free-form is left
+    alone for backward compat.
+    """
+    return bool(_TOKEN_SHAPED_REASON_RE.match(reason))
+
+
 class PlanBlockedOut(_Base):
     """Typed lifecycle payload for an unfulfillable plan-approval request."""
 
@@ -323,6 +376,22 @@ VisibilityEventKind = Literal[
     "capability_changed",
     "capability_manifest_updated",
     "batch_summary",
+    # #40 Phase 1: success-path instrumentation for the Codex App Server
+    # JSON-RPC ``initialize`` handshake. Carries ``elapsed_ms`` and
+    # ``prompt_byte_size`` so we can revisit the default initialize
+    # timeout (90s — see ``APP_SERVER_INITIALIZE_TIMEOUT_ENV``) with real
+    # success-path data instead of the single 17s anecdote we have today.
+    # Closes the meta-observability gap noted in the #40 thread:
+    # "10-minute silence is indistinguishable from 'agent is genuinely
+    # thinking hard' until the failure event lands."
+    "app_server_initialize_completed",
+    # #40 Phase 1: periodic progress envelope emitted while we are still
+    # waiting on the ``initialize`` reply. Cadence is
+    # ``APP_SERVER_INITIALIZE_PROGRESS_INTERVAL_ENV`` (default 30s). Lets
+    # the lead observe a slow cold start without staring at a 90s
+    # silence; carries ``attempt``, ``elapsed_s``, ``last_observed_pid``,
+    # and (Linux only, best-effort) ``last_observed_cpu_pct``.
+    "app_server_initialize_progress",
 ]
 
 VisibilitySeverity = Literal["debug", "info", "warn", "error"]
@@ -431,6 +500,8 @@ def parse_protocol_text(text: str) -> _Base | None:
         "capability_changed",
         "capability_manifest_updated",
         "batch_summary",
+        "app_server_initialize_completed",
+        "app_server_initialize_progress",
     }:
         return _safe_load(VisibilityEvent, raw)
     return None

--- a/src/claude_anyteam/protocol_io.py
+++ b/src/claude_anyteam/protocol_io.py
@@ -891,6 +891,73 @@ def send_idle_notification(team: str, sender: str, reason: str = "available") ->
     )
 
 
+def emit_initialize_timeout_visibility_degraded(
+    *,
+    team: str,
+    agent: str,
+    backend: str,
+    phase: str,
+    incident_id: str,
+    sender: str | None = None,
+    shutdown_request: bool = False,
+    error: str | None = None,
+) -> VisibilityEvent:
+    """Emit a typed ``visibility_degraded`` envelope for a prose-bound App
+    Server ``initialize`` timeout (#40 Phase 1, Gap 2).
+
+    Task-bound initialize timeouts route to ``task_blocked`` with a
+    typed reason via ``send_task_blocked``. Prose-bound timeouts have no
+    ``task_id`` to block, so they emit this typed envelope instead — the
+    lead's event log and mailbox carry the structured detail; the prose
+    response (which still ships, because the sender's turn needs *some*
+    completion) becomes a thin pointer at the incident_id.
+
+    ``phase`` distinguishes the prose context (typically
+    ``"prose_bound"``) from any future variants. ``shutdown_request``
+    flags whether the timeout was hit while honoring an in-flight
+    shutdown_request — the worst-UX variant from the #40 issue thread,
+    where a no-op shutdown burned the full 600s.
+
+    Fan-out: event log always, mailbox always (the lead must see this
+    at native fidelity rather than scraping stderr).
+    """
+
+    event_id = f"{agent}:init-timeout-prose:{int(time.time() * 1000)}"
+    payload: dict[str, Any] = {
+        "surface": "app_server_initialize_timeout",
+        "phase": phase,
+        "incident_id": incident_id,
+        "shutdown_request": bool(shutdown_request),
+    }
+    if sender is not None:
+        payload["sender"] = sender
+    if error is not None:
+        payload["raw_backend_error"] = _bounded_text(error, limit=600)
+    envelope = VisibilityEvent(
+        kind="visibility_degraded",
+        event_id=event_id,
+        team=team,
+        agent=agent,
+        backend=backend,
+        seq=0,
+        severity="error",
+        summary=(
+            f"App Server initialize timed out (prose-bound; "
+            f"shutdown_request={bool(shutdown_request)})"
+        )[:300],
+        visibility={
+            "mailbox": True,
+            "task_state": False,
+            "event_log": True,
+            "stderr": True,
+        },
+        payload=payload,
+    )
+    append_event(team, agent, envelope)
+    send_visibility_event_to_lead(team, agent, envelope)
+    return envelope
+
+
 def emit_peer_steer_rejection(
     *,
     team: str,

--- a/src/claude_anyteam/wrapper_server.py
+++ b/src/claude_anyteam/wrapper_server.py
@@ -58,7 +58,9 @@ from .env import (
 from .messages import (
     BatchSummaryChild,
     BatchSummaryPayload,
+    KNOWN_TASK_BLOCKED_REASONS,
     VisibilityEvent,
+    is_token_shaped_reason,
     parse_protocol_text,
 )
 from . import protocol_io
@@ -521,6 +523,37 @@ def _normalise_lifecycle_send_body(kind: str, body: str) -> str:
     if payload is None:
         raise ToolError(f"body is not a valid {kind!r} protocol payload")
     return payload.model_dump_json(by_alias=True, exclude_none=True)
+
+
+def _task_blocked_reason_drift(body: str) -> str | None:
+    """Return the offending reason if a typed ``task_blocked`` body uses a
+    token-shaped reason that is not in ``KNOWN_TASK_BLOCKED_REASONS``.
+
+    #40 Phase 1, graduated rung 1+2 (declare + suggest): the
+    ``task_blocked.reason`` field is an open ``str`` for backward compat,
+    but new machine-readable tokens (e.g. ``app_server_initialize_timeout``)
+    are registered. Token-shaped reasons that are NOT in the registry
+    likely indicate either a typo or a missing registration step. We
+    surface those via a ``visibility_degraded`` warn at the wrapper layer
+    so the lead can see drift, without blocking delivery (free-form prose
+    reasons remain legal — only ``snake_case`` token-shaped strings are
+    policed).
+    """
+
+    try:
+        raw = json.loads(body)
+    except (TypeError, ValueError):
+        return None
+    if not isinstance(raw, dict):
+        return None
+    reason = raw.get("reason")
+    if not isinstance(reason, str):
+        return None
+    if reason in KNOWN_TASK_BLOCKED_REASONS:
+        return None
+    if not is_token_shaped_reason(reason):
+        return None
+    return reason
 
 
 def _run_git(
@@ -1269,6 +1302,43 @@ def build_server(argv: list[str] | None = None) -> FastMCP:
             raise ToolError(f"`kind` must be one of {SEND_MESSAGE_KINDS}; got {kind!r}")
         if kind in LIFECYCLE_SEND_MESSAGE_KINDS:
             body = _normalise_lifecycle_send_body(kind, body)
+            if kind == "task_blocked":
+                drifted = _task_blocked_reason_drift(body)
+                if drifted is not None:
+                    # #40 Phase 1: surface drift in token-shaped
+                    # task_blocked reasons without blocking delivery.
+                    # The §2 contract is that the lead can see the
+                    # mismatch — if a typo or missed registry update is
+                    # leaking into typed lifecycle, the warn event is
+                    # how they catch it.
+                    try:
+                        warn_event = _make_event(
+                            kind="visibility_degraded",
+                            severity="warn",
+                            summary=(
+                                f"task_blocked emitted with unregistered "
+                                f"reason token: {drifted!r}"
+                            ),
+                            mailbox=True,
+                            payload={
+                                "surface": "task_blocked_unknown_reason",
+                                "reason": drifted,
+                                "registered_reasons": sorted(
+                                    KNOWN_TASK_BLOCKED_REASONS
+                                ),
+                                "impact": (
+                                    "Recipients filtering on task_blocked.reason "
+                                    "may not match this value. Either add the "
+                                    "token to KNOWN_TASK_BLOCKED_REASONS or "
+                                    "use a free-form prose reason instead."
+                                ),
+                            },
+                        )
+                        _fanout_visibility_event(warn_event)
+                    except Exception as e:
+                        logger.warning(
+                            "task_blocked_drift_emit_failed: %s", e
+                        )
         if to == self_name:
             raise ToolError(f"refusing to send message to self ({self_name!r})")
         try:

--- a/tests/test_app_server_initialize_visibility.py
+++ b/tests/test_app_server_initialize_visibility.py
@@ -1,0 +1,358 @@
+"""Regression tests for the App Server ``initialize`` visibility surface
+(issue #40 Phase 1).
+
+The bug being protected against: until v0.8.1, the JSON-RPC ``initialize``
+handshake was bounded by a 600s default timeout and emitted nothing while
+waiting. From the user's #40 thread:
+
+    > 10-minute silence is indistinguishable from "agent is genuinely
+    > thinking hard" until the failure event lands.
+
+That is the §2 visibility-parity gap. Phase 1 closes it with three
+typed-event invariants this test pins:
+
+1. Default initialize budget is 90s (not 600s); env override respected.
+2. On success, ``app_server_initialize_completed`` carries ``elapsed_ms``
+   and ``prompt_byte_size`` so we can revisit the 90s default with real
+   data instead of the single 17s anecdote we have today.
+3. While waiting, ``app_server_initialize_progress`` events are emitted
+   at the configured cadence (default 30s; 0 disables).
+"""
+
+from __future__ import annotations
+
+import json
+import queue
+import subprocess
+import threading
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from claude_anyteam import codex as codex_mod
+from claude_anyteam.app_server import AppServerClient
+
+
+class _StdinWriter:
+    def __init__(self, feed_fn) -> None:
+        self._feed = feed_fn
+        self._closed = False
+
+    def write(self, data: str) -> int:
+        if self._closed:
+            raise BrokenPipeError("closed")
+        self._feed(data)
+        return len(data)
+
+    def flush(self) -> None:
+        pass
+
+    def close(self) -> None:
+        self._closed = True
+
+
+class _QueueReader:
+    def __init__(self, q: "queue.Queue[str]") -> None:
+        self._q = q
+
+    def __iter__(self):
+        while True:
+            line = self._q.get()
+            if not line:
+                return
+            yield line
+
+    def readline(self) -> str:
+        return self._q.get()
+
+    def close(self) -> None:
+        pass
+
+
+class _FakeProcess:
+    def __init__(self, responder, *, delay_s: float = 0.0) -> None:
+        self._out_queue: "queue.Queue[str]" = queue.Queue()
+        self._responder = responder
+        self._delay_s = delay_s
+        self.returncode: int | None = None
+        self.pid = 99999
+        self._stdout_reader = _QueueReader(self._out_queue)
+        self._stderr_reader = _QueueReader(queue.Queue())
+        self.stdin = _StdinWriter(self._feed)
+        self.stdout = self._stdout_reader
+        self.stderr = self._stderr_reader
+
+    def _feed(self, raw: str) -> None:
+        try:
+            msg = json.loads(raw)
+        except json.JSONDecodeError:
+            return
+        if self._delay_s > 0:
+            # Schedule the response after a delay, on a worker thread.
+            def _delayed() -> None:
+                import time
+
+                time.sleep(self._delay_s)
+                for line in self._responder(msg):
+                    self._out_queue.put(line + "\n")
+
+            threading.Thread(target=_delayed, daemon=True).start()
+            return
+        for line in self._responder(msg):
+            self._out_queue.put(line + "\n")
+
+    def poll(self) -> int | None:
+        return self.returncode
+
+    def terminate(self) -> None:
+        self.returncode = 0
+        self._out_queue.put("")
+
+    def kill(self) -> None:
+        self.returncode = -9
+        self._out_queue.put("")
+
+    def wait(self, timeout: float | None = None) -> int:
+        return self.returncode or 0
+
+
+def _make_client_with(responder, *, delay_s: float = 0.0):
+    fake = _FakeProcess(responder, delay_s=delay_s)
+    with patch.object(subprocess, "Popen", return_value=fake):
+        client = AppServerClient()
+        client.start()
+    return client, fake
+
+
+def _captured_emitter():
+    captured: list[dict[str, Any]] = []
+
+    def emit(*, kind, severity, summary, payload, visibility=None):
+        captured.append(
+            {
+                "kind": kind,
+                "severity": severity,
+                "summary": summary,
+                "payload": dict(payload),
+                "visibility": dict(visibility or {}),
+            }
+        )
+        return None
+
+    return captured, emit
+
+
+def _ok_responder(msg):
+    yield json.dumps({"jsonrpc": "2.0", "id": msg["id"], "result": {"server": "ok"}})
+
+
+def test_initialize_completed_event_includes_elapsed_and_prompt_size(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(
+        codex_mod.APP_SERVER_INITIALIZE_PROGRESS_INTERVAL_ENV, raising=False
+    )
+    monkeypatch.delenv(
+        codex_mod.APP_SERVER_INITIALIZE_TIMEOUT_ENV, raising=False
+    )
+
+    client, _ = _make_client_with(_ok_responder)
+    captured, emit = _captured_emitter()
+    try:
+        codex_mod._initialize_with_progress_events(
+            client,
+            emit_visibility=emit,
+            prompt_byte_size=2048,
+        )
+    finally:
+        client.close()
+
+    completed = [c for c in captured if c["kind"] == "app_server_initialize_completed"]
+    assert len(completed) == 1, f"Expected one completed event, got {captured}"
+    payload = completed[0]["payload"]
+    assert payload["prompt_byte_size"] == 2048
+    assert payload["elapsed_ms"] >= 0
+    assert payload["timeout_s"] == 90.0
+    assert completed[0]["severity"] == "info"
+    assert completed[0]["visibility"]["event_log"] is True
+    assert completed[0]["visibility"]["mailbox"] is False
+
+
+def test_initialize_default_timeout_is_90s(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pin: the default initialize budget is 90s, not the legacy 600s."""
+
+    monkeypatch.delenv(
+        codex_mod.APP_SERVER_INITIALIZE_TIMEOUT_ENV, raising=False
+    )
+
+    captured_timeouts: list[float] = []
+
+    class _ProbeClient:
+        pid = 1234
+
+        def initialize(self, *, timeout: float | None = None) -> Any:
+            captured_timeouts.append(timeout if timeout is not None else -1.0)
+            return {"server": "ok"}
+
+    _, emit = _captured_emitter()
+    codex_mod._initialize_with_progress_events(
+        _ProbeClient(),
+        emit_visibility=emit,
+        prompt_byte_size=0,
+    )
+
+    assert captured_timeouts == [90.0], (
+        "Default initialize timeout must be 90s; got "
+        f"{captured_timeouts}. Fix the default in codex.py if you intended "
+        "to change it — the regression test is here exactly so the change "
+        "is deliberate."
+    )
+
+
+def test_initialize_timeout_env_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pin: env override flows through to client.initialize()."""
+
+    monkeypatch.setenv(
+        codex_mod.APP_SERVER_INITIALIZE_TIMEOUT_ENV, "12.5"
+    )
+
+    captured_timeouts: list[float] = []
+
+    class _ProbeClient:
+        pid = 1234
+
+        def initialize(self, *, timeout: float | None = None) -> Any:
+            captured_timeouts.append(timeout if timeout is not None else -1.0)
+            return {"server": "ok"}
+
+    _, emit = _captured_emitter()
+    codex_mod._initialize_with_progress_events(
+        _ProbeClient(),
+        emit_visibility=emit,
+        prompt_byte_size=0,
+    )
+
+    assert captured_timeouts == [12.5]
+
+
+def test_initialize_progress_events_emitted_during_slow_handshake(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Slow handshake → at least one ``app_server_initialize_progress``
+    fires before the success event. Without this the lead has no signal
+    distinguishing slow init from a hung process.
+    """
+
+    # Tight intervals so the test stays fast: 0.5s budget, 0.1s progress
+    # cadence, ~0.3s simulated initialize delay.
+    monkeypatch.setenv(
+        codex_mod.APP_SERVER_INITIALIZE_TIMEOUT_ENV, "0.5"
+    )
+    monkeypatch.setenv(
+        codex_mod.APP_SERVER_INITIALIZE_PROGRESS_INTERVAL_ENV, "0.1"
+    )
+
+    client, _ = _make_client_with(_ok_responder, delay_s=0.3)
+    captured, emit = _captured_emitter()
+    try:
+        codex_mod._initialize_with_progress_events(
+            client,
+            emit_visibility=emit,
+            prompt_byte_size=42,
+        )
+    finally:
+        client.close()
+
+    progress = [c for c in captured if c["kind"] == "app_server_initialize_progress"]
+    assert progress, (
+        "Expected at least one app_server_initialize_progress event during a "
+        f"slow handshake. Got: {[c['kind'] for c in captured]}"
+    )
+    payload = progress[0]["payload"]
+    assert payload["attempt"] >= 1
+    assert payload["elapsed_s"] >= 0.0
+    assert payload["timeout_s"] == 0.5
+    assert payload["progress_interval_s"] == 0.1
+    assert payload["prompt_byte_size"] == 42
+    # last_observed_pid is best-effort but must be present (even if None on
+    # platforms where the fake client doesn't expose it).
+    assert "last_observed_pid" in payload
+
+    completed = [c for c in captured if c["kind"] == "app_server_initialize_completed"]
+    assert len(completed) == 1
+
+
+def test_initialize_progress_disabled_when_interval_zero(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pin: setting the progress interval to 0 disables emission entirely.
+    Operators who don't want the periodic noise can opt out cleanly.
+    """
+
+    monkeypatch.setenv(
+        codex_mod.APP_SERVER_INITIALIZE_TIMEOUT_ENV, "0.5"
+    )
+    monkeypatch.setenv(
+        codex_mod.APP_SERVER_INITIALIZE_PROGRESS_INTERVAL_ENV, "0"
+    )
+
+    client, _ = _make_client_with(_ok_responder, delay_s=0.3)
+    captured, emit = _captured_emitter()
+    try:
+        codex_mod._initialize_with_progress_events(
+            client,
+            emit_visibility=emit,
+            prompt_byte_size=0,
+        )
+    finally:
+        client.close()
+
+    progress = [c for c in captured if c["kind"] == "app_server_initialize_progress"]
+    assert progress == [], (
+        "Setting interval=0 must disable progress emission entirely. "
+        f"Got: {progress}"
+    )
+
+    # Success event still fires.
+    completed = [c for c in captured if c["kind"] == "app_server_initialize_completed"]
+    assert len(completed) == 1
+
+
+def test_initialize_timeout_propagates_underlying_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When initialize times out, the wrapper must re-raise the App Server
+    error rather than swallowing it. Loop-side handlers key on the error
+    message ("did not respond to initialize") to route to typed
+    task_blocked instead of prose_reply.
+    """
+
+    monkeypatch.setenv(
+        codex_mod.APP_SERVER_INITIALIZE_TIMEOUT_ENV, "0.2"
+    )
+    monkeypatch.setenv(
+        codex_mod.APP_SERVER_INITIALIZE_PROGRESS_INTERVAL_ENV, "0"
+    )
+
+    def never_responds(_msg):
+        return iter([])
+
+    client, _ = _make_client_with(never_responds)
+    _, emit = _captured_emitter()
+    try:
+        from claude_anyteam.app_server import AppServerError
+
+        with pytest.raises(AppServerError, match="did not respond to initialize"):
+            codex_mod._initialize_with_progress_events(
+                client,
+                emit_visibility=emit,
+                prompt_byte_size=0,
+            )
+    finally:
+        client.close()

--- a/tests/test_app_server_mcp_config.py
+++ b/tests/test_app_server_mcp_config.py
@@ -45,7 +45,7 @@ def _capture_thread_start_config(
         def start(self):
             pass
 
-        def initialize(self):
+        def initialize(self, **_kwargs):
             return {}
 
         def thread_start(self, **kwargs):

--- a/tests/test_app_server_process_group.py
+++ b/tests/test_app_server_process_group.py
@@ -1,0 +1,182 @@
+"""Regression test for AppServerClient process-group teardown (issue #40).
+
+Issue #40 — concurrent codex-* spawn deadlock: the second-or-later codex
+app-server cold start within the same long-lived wrapper process hangs at
+JSON-RPC ``initialize`` for the full 600s timeout while burning ~100% CPU.
+The wrapper's first ``client.close()`` SIGTERMs only the codex-app-server
+leader; helper subprocesses Codex forked for auth refresh / model I/O /
+network handshake survived the close because they were in the parent's
+process group. On the next per-turn ``AppServerClient`` cold start they
+collided with the new process's open fds / sockets / cache locks.
+
+The fix puts each ``AppServerClient``'s subprocess tree in its own POSIX
+session (``start_new_session=True``) and SIGTERMs the entire process group
+on close (``terminate_process_group=True``). This test pins both flags so
+a future refactor cannot silently revert to the leak-on-close mode in #40.
+
+Mirrors the convention the gemini ACP transport already uses
+(``backends/gemini/acp.py``: ``client.terminate_process_group(...)``).
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from claude_anyteam.app_server import AppServerClient
+
+
+def test_app_server_client_starts_in_new_session() -> None:
+    """``start_new_session=True`` must be passed to subprocess.Popen so the
+    Codex app-server's helper subprocesses live in their own process group,
+    not the wrapper's. Required for ``terminate_process_group`` to
+    distinguish "this turn's tree" from "the wrapper itself."
+    """
+
+    captured: dict[str, Any] = {}
+
+    class _StoppedReader:
+        def __iter__(self):
+            if False:
+                yield  # pragma: no cover
+
+        def readline(self) -> str:
+            return ""
+
+        def close(self) -> None:
+            pass
+
+    class _Sink:
+        def __init__(self) -> None:
+            self._closed = False
+
+        def write(self, data: str) -> int:
+            return len(data)
+
+        def flush(self) -> None:
+            pass
+
+        def close(self) -> None:
+            self._closed = True
+
+    class _FakeProcess:
+        def __init__(self) -> None:
+            self.pid = 4242
+            self.returncode: int | None = None
+            self.stdin = _Sink()
+            self.stdout = _StoppedReader()
+            self.stderr = _StoppedReader()
+
+        def poll(self) -> int | None:
+            return self.returncode
+
+        def terminate(self) -> None:
+            self.returncode = 0
+
+        def kill(self) -> None:
+            self.returncode = -9
+
+        def wait(self, timeout: float | None = None) -> int:
+            return self.returncode or 0
+
+    def fake_popen(*args: Any, **kwargs: Any) -> _FakeProcess:
+        captured.update(kwargs)
+        return _FakeProcess()
+
+    with patch.object(subprocess, "Popen", side_effect=fake_popen):
+        client = AppServerClient()
+        client.start()
+        try:
+            assert captured.get("start_new_session") is True, (
+                "AppServerClient must launch with start_new_session=True so "
+                "the codex-app-server subprocess tree lives in its own POSIX "
+                "session — see issue #40."
+            )
+        finally:
+            client.close(timeout=0.1)
+
+
+def test_app_server_client_terminate_process_group_flag_set() -> None:
+    """``terminate_process_group=True`` must propagate to ``close()`` so
+    SIGTERM goes to the whole tree, not just the leader.
+    """
+
+    client = AppServerClient()
+    assert client._terminate_process_group is True, (
+        "AppServerClient must opt into process-group termination so "
+        "client.close() reaps codex-app-server's helper subprocesses — "
+        "see issue #40."
+    )
+
+
+@pytest.mark.skipif(
+    sys.platform != "linux" or os.environ.get("CI") == "true",
+    reason="real-process integration test; runs on developer Linux only",
+)
+def test_app_server_close_signals_helper_children() -> None:
+    """End-to-end pin: launch a tiny shell script that forks a long-lived
+    helper child, then assert the helper dies when the leader is
+    ``close()``'d. Without process-group-aware teardown, the helper
+    survives — which is the leak that produces the #40 hang on the next
+    cold start.
+
+    Skipped in CI / non-Linux to keep the deterministic suite hermetic;
+    run locally with ``pytest tests/test_app_server_process_group.py
+    -k close_signals --no-header``.
+    """
+
+    # Minimal "app-server" that:
+    #   1. Forks a sleeping helper child (writes its PID to stdout for us).
+    #   2. Reads from stdin so close()'s stdin-EOF can wake the leader.
+    leader_argv = [
+        "bash",
+        "-c",
+        # Run the helper in the background, print its PID, then read until EOF.
+        "sleep 600 & echo $! ; cat >/dev/null",
+    ]
+
+    proc = subprocess.Popen(
+        leader_argv,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+        start_new_session=True,
+    )
+    try:
+        assert proc.stdout is not None
+        helper_pid = int(proc.stdout.readline().strip())
+        # Helper alive (sanity).
+        os.kill(helper_pid, 0)
+
+        # Mimic AppServerClient close: SIGTERM the *process group*.
+        try:
+            pgid = os.getpgid(proc.pid)
+            os.killpg(pgid, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+        proc.wait(timeout=5)
+
+        # Give the kernel a moment to reap the helper.
+        for _ in range(50):
+            try:
+                os.kill(helper_pid, 0)
+            except ProcessLookupError:
+                break
+            else:
+                import time
+
+                time.sleep(0.05)
+
+        with pytest.raises(ProcessLookupError):
+            os.kill(helper_pid, 0)
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=2)

--- a/tests/test_checkpoint_timeout_e2e.py
+++ b/tests/test_checkpoint_timeout_e2e.py
@@ -46,7 +46,7 @@ class _NeverCompletesAppServer:
     def start(self):
         pass
 
-    def initialize(self):
+    def initialize(self, **_kwargs):
         return {}
 
     def thread_start(self, **kwargs):

--- a/tests/test_codex_startup_visibility.py
+++ b/tests/test_codex_startup_visibility.py
@@ -1,0 +1,182 @@
+"""Regression tests for the codex adapter's startup-crash visibility path.
+
+Issue #32 — WSL2 Codex teammate spawn writes ``tmuxPaneId`` to team config
+but no codex process exists / no registration ever fires. Reporter
+root-caused this to ``httpx==1.0.dev3`` being promoted into the tool venv,
+which broke ``from fastmcp import FastMCP`` at import time. The codex
+spawn-shim then crashed inside its tmux pane and the wrapper's
+``_probe_wrapper_mcp`` (and therefore ``feature_test``) raised a
+``RuntimeError`` *before* the codex adapter's main loop and registration
+ran. Result: the lead saw a teammate that never registered, with no
+telemetry to distinguish "still booting" from "dead at bootstrap."
+
+The fix mirrors what the gemini and kimi backends already do (see
+``test_startup_visibility.py``): wrap bootstrap in a try/except that fans
+out a structured ``visibility_degraded`` envelope to the lead mailbox +
+event log AND records a diagnostic incident. The test below pins that
+behavior so a future refactor cannot silently revert to the
+silent-spawn-failure mode in #32.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from claude_teams import messaging as cs_messaging  # type: ignore[import-untyped]
+
+from claude_anyteam import codex as codex_mod
+from claude_anyteam import diagnostics
+from claude_anyteam import loop as codex_loop
+from claude_anyteam import protocol_io as pio
+from claude_anyteam.config import Settings
+
+
+@pytest.fixture
+def events_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    base = tmp_path / "home" / ".claude" / "teams"
+    monkeypatch.setattr(cs_messaging, "TEAMS_DIR", base)
+    return base
+
+
+def _settings(tmp_path: Path) -> Settings:
+    return Settings(
+        team_name="team-codex",
+        agent_name="codex-alice",
+        cwd=tmp_path,
+        poll_interval_s=0.01,
+        color="cyan",
+        plan_mode_required=False,
+        codex_binary="codex-broken",
+    )
+
+
+def _lead_visibility_messages(root: Path, *, team: str = "team-codex") -> list[dict[str, Any]]:
+    path = root / team / "inboxes" / "team-lead.json"
+    if not path.exists():
+        return []
+    raw = json.loads(path.read_text())
+    return [
+        json.loads(message["text"])
+        for message in raw
+        if message.get("messageKind") == "visibility_degraded"
+    ]
+
+
+def test_codex_feature_test_failure_fans_out_visibility_degraded(
+    events_root: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``feature_test`` raising must surface to the lead, not exit silently.
+
+    Models the #32 root cause: the wrapper-MCP probe inside ``feature_test``
+    hits an ``ImportError``-equivalent (``from fastmcp import FastMCP``
+    failing because ``httpx==1.0.dev3`` was promoted into the venv) and
+    raises ``RuntimeError("wrapper build_server() probe failed: ...")``
+    before ``register()`` runs. The lead must see a ``visibility_degraded``
+    envelope (event log + mailbox) and a ``record_incident`` diagnostic.
+    """
+
+    incidents: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        diagnostics,
+        "record_incident",
+        lambda **kwargs: (incidents.append(kwargs) or "inc-test"),
+    )
+
+    def crash(
+        binary: str,
+        *,
+        mcp_probe: bool = False,
+        team: str | None = None,
+        agent_name: str | None = None,
+    ) -> None:
+        # The wire shape codex.py:_probe_wrapper_mcp would produce in
+        # the httpx-version-mismatch scenario.
+        raise RuntimeError(
+            f"wrapper build_server() probe failed: rc=1 "
+            f"stderr='AttributeError: module \\'httpx\\' has no attribute "
+            f"\\'TransportError\\''"
+        )
+
+    monkeypatch.setattr(codex_mod, "feature_test", crash)
+
+    # ``register`` should never get called if feature_test fails; if it
+    # does, we want the test to fail loudly rather than silently invoke
+    # the real config path.
+    register_calls: list[Any] = []
+    monkeypatch.setattr(
+        codex_loop,
+        "register",
+        lambda *args, **kwargs: register_calls.append((args, kwargs)),
+    )
+
+    assert codex_loop.run(_settings(tmp_path)) == 1
+    assert register_calls == []
+
+    events = pio.read_events("team-codex", "codex-alice")
+    assert len(events) == 1
+    event = events[0]
+    assert event.kind == "visibility_degraded"
+    assert event.severity == "error"
+    assert event.visibility.mailbox is True
+    assert event.visibility.event_log is True
+    assert event.payload["surface"] == "adapter_startup"
+    assert event.payload["phase"] == "feature_test"
+    assert event.payload["codex_binary"] == "codex-broken"
+    raw = event.payload["raw_backend_error"]
+    assert raw["type"] == "builtins.RuntimeError"
+    assert "wrapper build_server() probe failed" in raw["message"]
+
+    lead_events = _lead_visibility_messages(events_root)
+    assert len(lead_events) == 1
+    assert lead_events[0]["event_id"] == event.event_id
+
+    assert len(incidents) == 1
+    incident = incidents[0]
+    assert incident["team"] == "team-codex"
+    assert incident["agent"] == "codex-alice"
+    assert incident["backend"] == "codex"
+    assert incident["error_class"] == "adapter_startup_crash"
+
+
+def test_codex_register_failure_fans_out_visibility_degraded(
+    events_root: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A registration failure (e.g. team config locked / unreadable)
+    must also surface to the lead — feature_test passes but register
+    raises, and the same visibility-parity contract applies.
+    """
+
+    incidents: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        diagnostics,
+        "record_incident",
+        lambda **kwargs: (incidents.append(kwargs) or "inc-test"),
+    )
+    monkeypatch.setattr(codex_mod, "feature_test", lambda *_a, **_kw: None)
+
+    def boom(*_args: Any, **_kwargs: Any) -> None:
+        raise RuntimeError("team config not found at /nope/config.json")
+
+    monkeypatch.setattr(codex_loop, "register", boom)
+
+    assert codex_loop.run(_settings(tmp_path)) == 1
+
+    events = pio.read_events("team-codex", "codex-alice")
+    assert len(events) == 1
+    event = events[0]
+    assert event.kind == "visibility_degraded"
+    assert event.payload["surface"] == "adapter_startup"
+    assert event.payload["phase"] == "registration"
+
+    lead_events = _lead_visibility_messages(events_root)
+    assert len(lead_events) == 1
+    assert lead_events[0]["payload"]["phase"] == "registration"
+    assert len(incidents) == 1
+    assert incidents[0]["error_class"] == "adapter_startup_crash"

--- a/tests/test_cross_impl_envelope_contract.py
+++ b/tests/test_cross_impl_envelope_contract.py
@@ -131,7 +131,7 @@ class _ContractAppServerClient:
     def start(self) -> None:
         pass
 
-    def initialize(self) -> dict[str, Any]:
+    def initialize(self, **_kwargs) -> dict[str, Any]:
         return {}
 
     def thread_start(self, **kwargs: Any) -> str:
@@ -201,7 +201,7 @@ class _RecoveringAppServerClient:
     def start(self) -> None:
         pass
 
-    def initialize(self) -> dict[str, Any]:
+    def initialize(self, **_kwargs) -> dict[str, Any]:
         return {}
 
     def thread_start(self, **kwargs: Any) -> str:
@@ -315,7 +315,7 @@ class _ContractGeminiAcpClient:
     def close(self) -> None:
         pass
 
-    def initialize(self) -> dict[str, Any]:
+    def initialize(self, **_kwargs) -> dict[str, Any]:
         return {"protocolVersion": 1}
 
     def session_new(self, **kwargs: Any) -> dict[str, str]:

--- a/tests/test_fork_dispatch.py
+++ b/tests/test_fork_dispatch.py
@@ -69,7 +69,7 @@ class _FakeClient:
     def start(self):
         pass
 
-    def initialize(self):
+    def initialize(self, **_kwargs):
         return {}
 
     def thread_start(self, **kwargs):

--- a/tests/test_prose_bound_initialize_timeout.py
+++ b/tests/test_prose_bound_initialize_timeout.py
@@ -1,0 +1,282 @@
+"""Regression tests for #40 Phase 1 — Gap 2 (prose-bound initialize
+timeout typed visibility_degraded fan-out).
+
+Until this fix, when a prose-bound turn (e.g. shutdown handshake, peer
+DM) hit the App Server initialize timeout, the only signal the lead
+received was an apologetic prose_reply: "I received your message but
+couldn't generate a reply." That's the §2 violation product-steward
+flagged in their pushback: collapse-to-prose instead of typed event.
+
+Per Gap 2 in the steward's brief:
+
+> Use Option B (visibility_degraded with surface tag) for the
+> prose-bound timeout path. Ship in this PR. The existing prose_reply
+> STAYS as the courtesy response (the shutdown_request handshake needs
+> SOME prose response to complete) — but rewrite it to be CONCISE and
+> reference the incident_id.
+
+These tests pin both halves: (a) typed event lands with the right
+discriminators (`surface`, `phase`, `shutdown_request`); (b) prose
+response is concise and points at `claude-anyteam diagnose`.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from claude_teams import messaging as cs_messaging  # type: ignore[import-untyped]
+
+from claude_anyteam import diagnostics
+from claude_anyteam import loop as codex_loop
+from claude_anyteam import protocol_io as pio
+from claude_anyteam.config import Settings
+
+
+@pytest.fixture
+def events_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    base = tmp_path / "home" / ".claude" / "teams"
+    monkeypatch.setattr(cs_messaging, "TEAMS_DIR", base)
+    monkeypatch.setattr(pio._m, "TEAMS_DIR", base)
+    monkeypatch.setattr(
+        diagnostics, "_diagnostics_dir",
+        lambda team, agent: base / team / "diagnostics" / agent,
+    )
+    return base
+
+
+def _settings(tmp_path: Path) -> Settings:
+    return Settings(
+        team_name="team-codex",
+        agent_name="codex-alice",
+        cwd=tmp_path,
+        poll_interval_s=0.01,
+        color="cyan",
+        plan_mode_required=False,
+        codex_binary="codex",
+    )
+
+
+def _initialize_timeout_result() -> SimpleNamespace:
+    """The shape ``app_server_invoke()`` returns when the JSON-RPC
+    ``initialize`` request times out.
+    """
+    return SimpleNamespace(
+        error=(
+            "app_server error: JSON-RPC stdio process did not respond to "
+            "initialize within 90.0s"
+        ),
+        exit_code=1,
+        events=[],
+        tool_call_events=0,
+    )
+
+
+def test_classify_failure_recognises_initialize_timeout() -> None:
+    """Pin: ``classify_failure`` returns the dedicated bucket
+    ``app_server_initialize_timeout`` for the App Server initialize
+    timeout error string. Routes the prose-fallback path to its
+    structured handler instead of the generic ``subprocess_nonzero_exit``
+    bucket.
+    """
+    assert (
+        diagnostics.classify_failure(_initialize_timeout_result())
+        == "app_server_initialize_timeout"
+    )
+
+
+def test_fallback_message_for_initialize_timeout_is_concise() -> None:
+    """Pin: prose response for initialize-timeout is a thin pointer at
+    the incident, not the apologetic preamble. The typed event is the
+    structured surface; prose stays minimal.
+    """
+    msg = diagnostics.fallback_message(
+        backend="codex",
+        incident_id="inc-12345678",
+        error_class="app_server_initialize_timeout",
+    )
+    # Must reference the incident id and the diagnose CLI hint.
+    assert "inc-12345678" in msg
+    assert "claude-anyteam diagnose --incident inc-12345678" in msg
+    # Must NOT contain the apologetic generic preamble.
+    assert "couldn't generate a reply" not in msg
+    # Must reference the typed event path so the lead knows where
+    # structured detail lives.
+    assert "visibility_degraded" in msg
+
+
+def test_fallback_message_for_other_classes_keeps_legacy_shape() -> None:
+    """Pin: only the initialize-timeout class gets the rewritten concise
+    pointer — other failures keep the legacy apologetic preamble. The
+    Phase 1 scope is limited; we don't widen the prose rewrite to the
+    long tail of failure classes.
+    """
+    msg = diagnostics.fallback_message(
+        backend="codex",
+        incident_id="inc-other",
+        error_class="subprocess_nonzero_exit",
+    )
+    assert "couldn't generate a reply" in msg
+    assert "inc-other" in msg
+
+
+def test_prose_fallback_emits_typed_visibility_degraded_for_initialize_timeout(
+    events_root: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end: ``_prose_fallback_reply`` for an initialize-timeout
+    failure emits a typed ``visibility_degraded`` envelope with
+    ``surface="app_server_initialize_timeout"`` and the right
+    discriminators. The lead can filter their event log on the surface
+    tag instead of grepping prose substrings.
+    """
+    state = codex_loop.LoopState(settings=_settings(tmp_path))
+    state.shutdown_requested = False
+
+    reply = codex_loop._prose_fallback_reply(
+        state,
+        sender="team-lead",
+        result=_initialize_timeout_result(),
+    )
+
+    # Prose courtesy response: concise pointer.
+    assert "incident_id=inc-" in reply
+    assert "claude-anyteam diagnose --incident" in reply
+
+    # Typed event landed in the agent's event log.
+    events = pio.read_events("team-codex", "codex-alice")
+    matching = [
+        e
+        for e in events
+        if e.kind == "visibility_degraded"
+        and e.payload.get("surface") == "app_server_initialize_timeout"
+    ]
+    assert len(matching) == 1, (
+        f"Expected one prose-bound timeout event, got {[e.kind for e in events]}"
+    )
+    event = matching[0]
+    assert event.severity == "error"
+    assert event.payload["phase"] == "prose_bound"
+    assert event.payload["shutdown_request"] is False
+    assert event.payload["sender"] == "team-lead"
+    assert event.payload["incident_id"].startswith("inc-")
+    assert "did not respond to initialize" in event.payload["raw_backend_error"]
+    assert event.visibility.mailbox is True
+    assert event.visibility.event_log is True
+
+
+def test_prose_fallback_marks_shutdown_request_when_in_progress(
+    events_root: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pin the worst-UX variant from #40: when a shutdown_request is
+    in-flight and initialize times out, the typed event carries
+    ``shutdown_request=True`` so the lead can filter for the no-op
+    shutdown burns specifically. Per team-lead's evidence:
+    ``{"type":"shutdown_request"}`` hangs the same 10 minutes.
+    """
+    state = codex_loop.LoopState(settings=_settings(tmp_path))
+    state.shutdown_requested = True
+
+    codex_loop._prose_fallback_reply(
+        state,
+        sender="team-lead",
+        result=_initialize_timeout_result(),
+    )
+
+    events = pio.read_events("team-codex", "codex-alice")
+    matching = [
+        e
+        for e in events
+        if e.kind == "visibility_degraded"
+        and e.payload.get("surface") == "app_server_initialize_timeout"
+    ]
+    assert len(matching) == 1
+    assert matching[0].payload["shutdown_request"] is True
+
+
+def test_prose_fallback_does_not_emit_typed_event_for_other_classes(
+    events_root: Path,
+    tmp_path: Path,
+) -> None:
+    """Pin: the typed event is gated on the initialize-timeout class.
+    Other failures (schema validation, generic crashes, etc.) DON'T
+    emit the surface-tagged event — keeps the §2 fix narrowly scoped to
+    the path the issue thread documents.
+    """
+    state = codex_loop.LoopState(settings=_settings(tmp_path))
+    state.shutdown_requested = False
+
+    other_failure = SimpleNamespace(
+        error="codex exec --output-schema produced non-JSON output",
+        exit_code=2,
+        events=[],
+        tool_call_events=0,
+    )
+    codex_loop._prose_fallback_reply(
+        state, sender="peer", result=other_failure
+    )
+
+    events = pio.read_events("team-codex", "codex-alice")
+    matching = [
+        e
+        for e in events
+        if e.kind == "visibility_degraded"
+        and e.payload.get("surface") == "app_server_initialize_timeout"
+    ]
+    assert matching == [], (
+        "Other failure classes must not emit the initialize-timeout "
+        "surface tag."
+    )
+
+
+def test_emit_initialize_timeout_helper_lands_in_lead_inbox(
+    events_root: Path,
+    tmp_path: Path,
+) -> None:
+    """The ``emit_initialize_timeout_visibility_degraded`` helper fans
+    out to BOTH the agent's event log AND the lead's inbox, matching
+    the convention of ``emit_peer_steer_rejection`` and
+    ``emit_adapter_startup_crash``. The lead must see this at native
+    fidelity in the inbox, not via stderr scrape.
+    """
+    pio.emit_initialize_timeout_visibility_degraded(
+        team="team-codex",
+        agent="codex-alice",
+        backend="codex",
+        phase="prose_bound",
+        incident_id="inc-abcd1234",
+        sender="team-lead",
+        shutdown_request=True,
+        error="raw error preserved here",
+    )
+
+    events = pio.read_events("team-codex", "codex-alice")
+    assert len(events) == 1
+    event = events[0]
+    assert event.kind == "visibility_degraded"
+    assert event.payload["surface"] == "app_server_initialize_timeout"
+    assert event.payload["phase"] == "prose_bound"
+    assert event.payload["shutdown_request"] is True
+    assert event.payload["incident_id"] == "inc-abcd1234"
+    assert "raw error preserved here" in event.payload["raw_backend_error"]
+
+    # Lead inbox carries the same envelope (downstream filter keys on
+    # messageKind=visibility_degraded + surface=...).
+    inbox_path = events_root / "team-codex" / "inboxes" / "team-lead.json"
+    assert inbox_path.exists()
+    inbox = json.loads(inbox_path.read_text())
+    matching = [
+        json.loads(m["text"])
+        for m in inbox
+        if m.get("messageKind") == "visibility_degraded"
+        and json.loads(m["text"]).get("payload", {}).get("surface")
+        == "app_server_initialize_timeout"
+    ]
+    assert len(matching) == 1
+    assert matching[0]["payload"]["incident_id"] == "inc-abcd1234"

--- a/tests/test_task_blocked_initialize_timeout.py
+++ b/tests/test_task_blocked_initialize_timeout.py
@@ -1,0 +1,118 @@
+"""Regression test for #40 Phase 1 — typed ``task_blocked.reason`` for
+the App Server ``initialize`` timeout path.
+
+Before this fix the wrapper used the raw error string as the
+``task_blocked.reason``: lead-side filters had to grep substrings like
+``"did not respond to initialize"`` to recognize the same failure mode
+across runs. After this fix, initialize timeouts surface a stable
+machine-readable token (``"app_server_initialize_timeout"``) so the
+lead's task view + automation can branch on it directly.
+
+This is the §2 visibility-parity win product-steward asked for in their
+#40 Phase 1 brief: "Replace prose_reply timeout fallback with typed
+lifecycle payload — Land as task_blocked with structured reason:
+'app_server_initialize_timeout' + incident_id."
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from claude_anyteam.loop import _classify_task_block_reason
+
+
+def test_initialize_timeout_classified_to_stable_token() -> None:
+    """The App Server initialize-handshake timeout error string the
+    underlying ``JsonRpcStdioClient`` raises must collapse to the stable
+    ``app_server_initialize_timeout`` token.
+    """
+
+    result = SimpleNamespace(
+        error=(
+            "app_server error: JSON-RPC stdio process did not respond to "
+            "initialize within 90.0s"
+        ),
+        exit_code=1,
+    )
+    assert _classify_task_block_reason(result) == "app_server_initialize_timeout"
+
+
+def test_initialize_timeout_token_case_insensitive() -> None:
+    """Pin: case-insensitive substring match. If the error string
+    upstream changes capitalization (e.g., 'Did Not Respond'), we still
+    classify correctly. Substring match is the only stable handle we
+    have on the upstream error wire shape today.
+    """
+
+    result = SimpleNamespace(
+        error="JSON-RPC stdio process Did Not Respond to initialize within 60.0s",
+        exit_code=1,
+    )
+    assert _classify_task_block_reason(result) == "app_server_initialize_timeout"
+
+
+def test_other_failures_preserve_raw_error_for_now() -> None:
+    """Pin: failures we haven't classified yet propagate their raw error
+    string verbatim — preserves prior behavior so this PR doesn't widen
+    the scope beyond initialize-timeout. The classifier vocabulary can
+    grow incrementally as new high-cost failure modes surface.
+    """
+
+    result = SimpleNamespace(
+        error="codex exec --output-schema produced non-JSON output",
+        exit_code=2,
+    )
+    assert _classify_task_block_reason(result) == (
+        "codex exec --output-schema produced non-JSON output"
+    )
+
+
+def test_no_error_falls_back_to_exit_code_summary() -> None:
+    """Pin: when there is no error string at all, fall back to a
+    generic exit-code summary (also matches prior behavior). Prevents
+    sending an empty ``reason`` string that downstream task-state
+    rendering would mis-render as "blocked: ".
+    """
+
+    result = SimpleNamespace(error="", exit_code=42)
+    assert _classify_task_block_reason(result) == (
+        "codex exited 42 with no structured result"
+    )
+
+
+def test_initialize_timeout_during_shutdown_uses_distinct_token() -> None:
+    """Pin: when initialize times out while the adapter is honoring an
+    in-flight shutdown_request, the ``reason`` is the distinct
+    ``app_server_shutdown_timeout`` token. Per product-steward's #40
+    Phase 1 brief: lets the lead surface a no-op shutdown burning the
+    budget separately from a work-turn timeout in the same
+    discriminator.
+    """
+
+    result = SimpleNamespace(
+        error=(
+            "app_server error: JSON-RPC stdio process did not respond to "
+            "initialize within 90.0s"
+        ),
+        exit_code=1,
+    )
+    assert _classify_task_block_reason(result, shutdown_requested=True) == (
+        "app_server_shutdown_timeout"
+    )
+    # And without the shutdown context, it remains the regular token.
+    assert _classify_task_block_reason(result, shutdown_requested=False) == (
+        "app_server_initialize_timeout"
+    )
+
+
+def test_both_initialize_tokens_are_in_known_registry() -> None:
+    """Pin: both new typed tokens emitted by the codex backend MUST be
+    in ``KNOWN_TASK_BLOCKED_REASONS``. Otherwise the wrapper-MCP
+    drift-warn validator would emit a ``visibility_degraded`` event for
+    every legitimate task_blocked emission — defeating the §2 invariant.
+    """
+
+    from claude_anyteam.messages import KNOWN_TASK_BLOCKED_REASONS
+
+    assert "app_server_initialize_timeout" in KNOWN_TASK_BLOCKED_REASONS
+    assert "app_server_shutdown_timeout" in KNOWN_TASK_BLOCKED_REASONS

--- a/tests/test_task_blocked_reason_drift.py
+++ b/tests/test_task_blocked_reason_drift.py
@@ -1,0 +1,321 @@
+"""Regression tests for the wrapper-MCP ``task_blocked.reason`` drift
+warn (#40 Phase 1, graduated rung 1+2).
+
+Per product-steward's requirement: stable token registry + wrapper-side
+warn for token-shaped reasons that aren't registered, but never block
+delivery. The §2 invariant: a typo in a stable token surfaces as a
+``visibility_degraded`` warn so the lead sees it; free-form prose
+reasons remain legal.
+
+These tests pin:
+
+1. Registered reason → no warn, payload delivered.
+2. Token-shaped unregistered reason → warn emitted, payload still delivered.
+3. Free-form prose reason → no warn (preserves backward compat for
+   existing reasons like "codex invocation crashed: ...").
+4. Both new typed tokens (``app_server_initialize_timeout`` and
+   ``app_server_shutdown_timeout``) are in the registry.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+from claude_teams.models import LeadMember, TeammateMember
+
+from claude_anyteam import protocol_io as pio
+from claude_anyteam.messages import (
+    KNOWN_TASK_BLOCKED_REASONS,
+    is_token_shaped_reason,
+)
+from claude_anyteam.wrapper_server import build_server
+
+
+def _member(name: str, color: str) -> TeammateMember:
+    return TeammateMember(
+        agentId=f"{name}@claude-anyteam",
+        name=name,
+        agentType="claude-anyteam",
+        model="codex-cli",
+        prompt="test",
+        color=color,
+        joinedAt=0,
+        tmuxPaneId="pane",
+        cwd="/tmp",
+        backendType="in-process",
+    )
+
+
+def _lead() -> LeadMember:
+    return LeadMember(
+        agentId="team-lead@claude-anyteam",
+        name="team-lead",
+        agentType="team-lead",
+        model="claude-opus",
+        joinedAt=0,
+        tmuxPaneId="",
+        cwd="/tmp",
+    )
+
+
+@pytest.fixture
+def identity(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Wrapper identity + team config matching the
+    ``test_wrapper_contract.py`` fixture pattern.
+    """
+    monkeypatch.setenv("CLAUDE_ANYTEAM_TEAM", "claude-anyteam")
+    monkeypatch.setenv("CLAUDE_ANYTEAM_NAME", "contract-test")
+    team_root = tmp_path / "teams"
+    monkeypatch.setattr(
+        "claude_anyteam.wrapper_server._cs_messaging.TEAMS_DIR", team_root
+    )
+    monkeypatch.setattr("claude_anyteam.protocol_io._m.TEAMS_DIR", team_root)
+
+    team_dir = team_root / "claude-anyteam"
+    team_dir.mkdir(parents=True, exist_ok=True)
+    (team_dir / "inboxes").mkdir(exist_ok=True)
+    config = {
+        "name": "claude-anyteam",
+        "createdAt": 0,
+        "leadAgentId": "team-lead@claude-anyteam",
+        "leadSessionId": "lead-session",
+        "members": [
+            _lead().model_dump(by_alias=True, exclude_none=True),
+            _member("contract-test", "magenta").model_dump(
+                by_alias=True, exclude_none=True
+            ),
+            _member("peer-a", "blue").model_dump(
+                by_alias=True, exclude_none=True
+            ),
+        ],
+    }
+    (team_dir / "config.json").write_text(json.dumps(config), encoding="utf-8")
+    (team_dir / "inboxes" / "contract-test.json").write_text(
+        "[]", encoding="utf-8"
+    )
+    monkeypatch.setattr(
+        "claude_anyteam.wrapper_server._cs_teams.TEAMS_DIR", team_root
+    )
+    return team_root
+
+
+def _call(mcp, name: str, arguments: dict) -> dict:
+    return asyncio.run(mcp.call_tool(name, arguments)).structured_content
+
+
+def _drift_warns() -> list:
+    """Read warn events emitted by the wrapper for our identity."""
+    events = pio.read_visibility_events("claude-anyteam", "contract-test")
+    return [
+        e
+        for e in events
+        if e.kind == "visibility_degraded"
+        and e.payload.get("surface") == "task_blocked_unknown_reason"
+    ]
+
+
+def _peer_a_inbox(team_root: Path) -> list[dict]:
+    path = team_root / "claude-anyteam" / "inboxes" / "peer-a.json"
+    if not path.exists():
+        return []
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_token_shape_recognises_snake_case() -> None:
+    """Pin: ``is_token_shaped_reason`` matches snake_case identifiers,
+    not prose. The wrapper-MCP validator gate uses this regex to decide
+    whether a value is a "token attempt" worth policing.
+    """
+    assert is_token_shaped_reason("app_server_initialize_timeout") is True
+    assert is_token_shaped_reason("plan_blocked_after_retry") is True
+
+    # Free-form prose / mixed case / spaces / colons all fail the gate.
+    assert is_token_shaped_reason("codex invocation crashed: foo") is False
+    assert is_token_shaped_reason("Codex Crashed") is False
+    assert is_token_shaped_reason("plan generation failed twice") is False
+    assert is_token_shaped_reason("app_server_initialize_timeout: 90s") is False
+
+
+def test_registered_reason_is_delivered_without_warn(identity: Path) -> None:
+    """Pin: the new ``app_server_initialize_timeout`` token passes
+    through cleanly — no drift warn fired, payload reaches peer's inbox.
+    """
+    mcp = build_server()
+    body = json.dumps(
+        {
+            "kind": "task_blocked",
+            "task_id": "42",
+            "reason": "app_server_initialize_timeout",
+        }
+    )
+
+    _call(
+        mcp,
+        "send_message",
+        {
+            "to": "peer-a",
+            "body": body,
+            "summary": "blocked",
+            "kind": "task_blocked",
+        },
+    )
+
+    inbox = _peer_a_inbox(identity)
+    assert len(inbox) == 1
+    payload = json.loads(inbox[0]["text"])
+    assert payload["reason"] == "app_server_initialize_timeout"
+    assert payload["task_id"] == "42"
+
+    assert _drift_warns() == [], (
+        "Registered token must NOT trigger a drift warn — only "
+        "unregistered token-shaped values should."
+    )
+
+
+def test_token_shaped_unregistered_reason_emits_warn_but_delivers(
+    identity: Path,
+) -> None:
+    """Pin: the §2 invariant — drift surfaces, doesn't break delivery.
+
+    A typo or unregistered new token is exactly what the wrapper-MCP
+    drift warn is designed to catch. The payload still reaches the
+    recipient (don't break the team), but a ``visibility_degraded``
+    event lands in the lead's event log so the gap is observable.
+    """
+    mcp = build_server()
+    body = json.dumps(
+        {
+            "kind": "task_blocked",
+            "task_id": "42",
+            "reason": "app_server_inititialize_timeout",  # typo!
+        }
+    )
+
+    _call(
+        mcp,
+        "send_message",
+        {
+            "to": "peer-a",
+            "body": body,
+            "summary": "blocked",
+            "kind": "task_blocked",
+        },
+    )
+
+    # Delivery preserved.
+    inbox = _peer_a_inbox(identity)
+    assert len(inbox) == 1
+    delivered_payload = json.loads(inbox[0]["text"])
+    assert delivered_payload["reason"] == "app_server_inititialize_timeout"
+
+    # Drift surfaced.
+    warns = _drift_warns()
+    assert len(warns) == 1, f"Expected 1 drift warn, got {len(warns)}"
+    warn = warns[0]
+    assert warn.severity == "warn"
+    assert warn.payload["reason"] == "app_server_inititialize_timeout"
+    assert (
+        "app_server_initialize_timeout"
+        in warn.payload["registered_reasons"]
+    )
+    assert warn.visibility.mailbox is True
+
+
+def test_free_form_prose_reason_is_silent(identity: Path) -> None:
+    """Pin: free-form prose reasons (existing legacy behavior) are NOT
+    policed. ``"codex invocation crashed: AbcdError(...)"`` etc. pass
+    through silently — the gate only fires on token-shaped values.
+    """
+    mcp = build_server()
+    body = json.dumps(
+        {
+            "kind": "task_blocked",
+            "task_id": "42",
+            "reason": "codex invocation crashed: BrokenPipeError(EOF)",
+        }
+    )
+
+    _call(
+        mcp,
+        "send_message",
+        {
+            "to": "peer-a",
+            "body": body,
+            "summary": "blocked",
+            "kind": "task_blocked",
+        },
+    )
+
+    inbox = _peer_a_inbox(identity)
+    assert len(inbox) == 1
+    assert "BrokenPipeError" in json.loads(inbox[0]["text"])["reason"]
+
+    assert _drift_warns() == [], (
+        "Free-form prose reasons must NOT trigger drift warns; the "
+        "registry only polices snake_case token-shaped values."
+    )
+
+
+def test_registry_includes_both_phase_1_tokens() -> None:
+    """Pin: both #40 Phase 1 tokens are in the registry. If they were
+    missing, every legitimate task_blocked emission from the codex loop
+    would trigger a drift warn — defeating the §2 invariant.
+    """
+    assert "app_server_initialize_timeout" in KNOWN_TASK_BLOCKED_REASONS
+    assert "app_server_shutdown_timeout" in KNOWN_TASK_BLOCKED_REASONS
+
+
+def test_recipient_parses_typed_task_blocked_via_discriminator(
+    identity: Path,
+) -> None:
+    """Pin: lead-side / peer-side recipients filter on
+    ``task_blocked.reason``, NOT on prose. Per
+    ``feedback_recipient_defined_concepts``: the wrapper-layer drift
+    warn only matters if recipients actually read the typed reason
+    field. This test asserts the recipient-side parse path returns a
+    structured ``TaskBlockedOut`` whose ``reason`` matches the
+    registered token — protecting against a future "simplification"
+    that collapses the handler back to prose-parsing.
+    """
+    from claude_anyteam.messages import TaskBlockedOut, parse_protocol_text
+
+    mcp = build_server()
+    body = json.dumps(
+        {
+            "kind": "task_blocked",
+            "task_id": "42",
+            "reason": "app_server_initialize_timeout",
+        }
+    )
+    _call(
+        mcp,
+        "send_message",
+        {
+            "to": "peer-a",
+            "body": body,
+            "summary": "blocked",
+            "kind": "task_blocked",
+        },
+    )
+
+    # Recipient picks up the message and parses it via the same path
+    # the lead's loop uses.
+    inbox = _peer_a_inbox(identity)
+    assert len(inbox) == 1
+    received = inbox[0]
+    assert received["messageKind"] == "task_blocked"
+
+    parsed = parse_protocol_text(received["text"])
+    assert isinstance(parsed, TaskBlockedOut), (
+        "Recipient must parse the typed payload via the structured "
+        f"protocol path, got {type(parsed).__name__}"
+    )
+    assert parsed.reason == "app_server_initialize_timeout", (
+        "Recipient reads the typed `reason` discriminator field, not "
+        "prose substring matching."
+    )
+    assert parsed.task_id == "42"
+    assert parsed.kind == "task_blocked"

--- a/tests/test_visibility_events.py
+++ b/tests/test_visibility_events.py
@@ -65,7 +65,7 @@ class _FakeClient:
     def start(self):
         pass
 
-    def initialize(self):
+    def initialize(self, **_kwargs):
         return {}
 
     def thread_start(self, **kwargs):
@@ -455,7 +455,7 @@ def test_app_server_no_checkpoint_after_300s_emits_turn_progress(monkeypatch):
         created.append(client)
         return client
 
-    ticks = iter([0, 0, 301, 301, 301, 301, 302, 303])
+    ticks = iter([0, 0, 0, 0, 0, 301, 301, 301, 301, 302, 303])
 
     def fake_monotonic():
         try:
@@ -507,7 +507,7 @@ def test_app_server_watchdog_fans_out_to_event_log_mailbox_and_active_form(
         created.append(client)
         return client
 
-    ticks = iter([0, 0, 0, 300, 301])
+    ticks = iter([0, 0, 0, 0, 0, 0, 300, 301])
 
     def fake_monotonic():
         try:
@@ -578,7 +578,7 @@ def test_app_server_watchdog_does_not_interrupt_without_opt_in(monkeypatch):
         created.append(client)
         return client
 
-    ticks = iter([0, 0, 0, 300, 350, 420, 421])
+    ticks = iter([0, 0, 0, 0, 0, 0, 300, 350, 420, 421])
 
     def fake_monotonic():
         try:
@@ -620,7 +620,7 @@ def test_app_server_watchdog_interrupts_only_when_opted_in(monkeypatch):
         created.append(client)
         return client
 
-    ticks = iter([0, 0, 0, 300, 350, 420])
+    ticks = iter([0, 0, 0, 0, 0, 0, 300, 350, 420])
 
     def fake_monotonic():
         try:

--- a/uv.lock
+++ b/uv.lock
@@ -132,11 +132,12 @@ wheels = [
 
 [[package]]
 name = "claude-anyteam"
-version = "0.7.11"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },
     { name = "filelock" },
+    { name = "httpx" },
     { name = "jsonschema" },
     { name = "pydantic" },
     { name = "watchfiles" },
@@ -153,6 +154,7 @@ dev = [
 requires-dist = [
     { name = "fastmcp", specifier = "==3.0.0b1" },
     { name = "filelock", specifier = "==3.16" },
+    { name = "httpx", specifier = ">=0.28,<1.0" },
     { name = "jsonschema", specifier = ">=4.20" },
     { name = "pydantic", specifier = ">=2.10" },
     { name = "watchfiles", specifier = ">=1.0" },


### PR DESCRIPTION
## Summary

Closes #32 and lands the §2 visibility-parity slice (Phase 1) of #40.
Phase 2 of #40 (root-cause for second-or-later cold-start hang) stays
open at reduced scope per the staged commitment — see "Phase 2 status"
below.

The diff falls into two halves:

- **#32 — Codex spawn-bootstrap silent-fail.** The reporter root-caused
  this to `httpx==1.0.dev3` being promoted into the tool venv (uv
  resolver allowed the prerelease under `>=0.27.1`/`>=0.28.1` from
  fastmcp + mcp + httpx-sse), the dev release dropped
  `httpx.TransportError`, `from fastmcp import FastMCP` raised at
  import time, and the codex spawn shim crashed inside its tmux pane
  with no telemetry. Two-track fix:
  1. Pin `httpx>=0.28,<1.0` in `pyproject.toml` so the resolver cannot
     promote the prerelease again.
  2. Wrap codex `loop.run()` bootstrap (feature_test, register,
     manifest load, signal setup) in a try/except mirroring the
     gemini/kimi/claude_native pattern v0.8.0 already shipped. On
     startup-crash, fan out a `visibility_degraded` envelope via
     `pio.emit_adapter_startup_crash(...)` and record an
     `adapter_startup_crash` incident. Codex was the lone outlier with
     bootstrap outside the try/except — that gap is what made #32
     invisible to the lead.

- **#40 Phase 1 — App Server initialize visibility-parity slice.** The
  user's evidence narrowed the bug from the original "concurrent-spawn
  race" framing to "second-or-later codex app-server cold-start within
  a long-lived wrapper hangs on JSON-RPC `initialize` for the full
  600s" — even on the smallest possible input (the shutdown-turn
  reproduction in
  https://github.com/JonathanRosado/claude-anyteam/issues/40#issuecomment-4374439477).
  The Phase 1 deliverables close the §2 visibility gap regardless of
  whether the underlying root-cause patch lands cleanly:
  - Default JSON-RPC initialize budget **600s → 90s** (the only
    successful empirical sample we have is ~17s on a parking-ack
    prompt; 90s is a 5x margin). Override with
    `CLAUDE_ANYTEAM_APP_SERVER_INITIALIZE_TIMEOUT_S`.
  - New typed `app_server_initialize_completed` event on every
    successful initialize, carrying `elapsed_ms` and
    `prompt_byte_size`. Closes the data gap so the 90s default can be
    revisited with measurements instead of the single 17s anecdote
    (per `feedback_meta_observability`).
  - New typed `app_server_initialize_progress` event emitted at the
    configured cadence (default 30s; 0 disables) while waiting on
    `initialize`. Payload includes `attempt`, `elapsed_s`,
    `last_observed_pid`, and (Linux only, best-effort from
    `/proc/<pid>/stat`) `last_observed_cpu_pct` — captures the user's
    empirical "100% CPU during the hang" signal.
  - Initialize-timeout failures route to a stable
    `task_blocked.reason = "app_server_initialize_timeout"` token (or
    `"app_server_shutdown_timeout"` when the adapter is honoring an
    in-flight shutdown_request) via a new
    `_classify_task_block_reason()` helper. Replaces the prior
    raw-error-string reason. Both new tokens live in
    `KNOWN_TASK_BLOCKED_REASONS`.
  - Prose-bound initialize timeouts (no `task_id` to block) now emit
    a typed `visibility_degraded` envelope via
    `pio.emit_initialize_timeout_visibility_degraded(...)` with
    `surface=app_server_initialize_timeout`, `phase=prose_bound`,
    `shutdown_request: bool`, `incident_id`, `sender`,
    `raw_backend_error`. The accompanying prose response is rewritten
    to a thin pointer at the incident_id and the typed event — no
    apologetic preamble.
  - Wrapper-MCP `send_message` emits a `visibility_degraded` warn
    (`surface=task_blocked_unknown_reason`) when a teammate sends a
    `task_blocked` body whose `reason` is token-shaped (snake_case)
    but not in `KNOWN_TASK_BLOCKED_REASONS`. Free-form prose reasons
    pass silently — the registry only polices typed tokens, gated by
    `is_token_shaped_reason()` regex `^[a-z][a-z0-9_]+$`. Graduated
    rung 1+2 per `feedback_graduated_enforcement_ladder`. Surfaces
    drift, never blocks delivery.
  - `AppServerClient` opts into `start_new_session=True` and
    `terminate_process_group=True`, so per-turn `client.close()`
    SIGTERMs the entire codex-app-server tree (leader + helper
    subprocesses Codex forks for auth refresh / model I/O). Mirrors
    the gemini ACP convention. One mitigation among several for the
    second-or-later cold-start hang; not the complete root-cause but
    proper teardown semantics regardless.

## Files changed

```
 pyproject.toml                                     |   9 +
 src/claude_anyteam/app_server.py                   |  35 +-
 src/claude_anyteam/codex.py                        | 227 +++-
 src/claude_anyteam/diagnostics.py                  |  19 +-
 src/claude_anyteam/env.py                          |  15 +
 src/claude_anyteam/loop.py                         | 192 ++--
 src/claude_anyteam/messages.py                     |  71 ++
 src/claude_anyteam/protocol_io.py                  |  68 ++
 src/claude_anyteam/wrapper_server.py               |  72 ++
 tests/test_app_server_initialize_visibility.py     | 358 ++++++
 tests/test_app_server_mcp_config.py                |   2 +-
 tests/test_app_server_process_group.py             | 182 +++
 tests/test_checkpoint_timeout_e2e.py               |   2 +-
 tests/test_codex_startup_visibility.py             | 182 +++
 tests/test_cross_impl_envelope_contract.py         |   6 +-
 tests/test_fork_dispatch.py                        |   2 +-
 tests/test_prose_bound_initialize_timeout.py       | 252 +++++
 tests/test_task_blocked_initialize_timeout.py      | 162 +++
 tests/test_task_blocked_reason_drift.py            | 321 ++++++
 tests/test_visibility_events.py                    |  10 +-
 uv.lock                                            |   4 +-
```

## Test plan

- [x] All Phase 1 + #32 regression suites pass at HEAD (30/30)
- [x] Full `pytest` suite passes at HEAD (1105 passed, 2 deselected)
- [x] Wheel-install httpx pin smoke confirms `httpx==0.28.1` resolves on
      a clean tool-venv install of the wheel built from this branch
- [x] Tree clean both pre- and post-evidence-capture
- [ ] Phase 2 root-cause investigation continues against
      user-volunteered `lsof`/`strace` captures (24h cap; ships
      Phase 1 standalone if root-cause doesn't crystallize — see
      "Phase 2 status" below)

## Empirical evidence

Captured at HEAD `8d67170bb2b546d302bf66fb478583eb65feccfd` per
`feedback_resolution_evidence_required` and the `--frozen` standing
pattern (clean tree pre- and post-capture):

```
$ test -z "$(git status --short)" && echo "[clean tree]"
[clean tree]
$ git rev-parse HEAD
8d67170bb2b546d302bf66fb478583eb65feccfd
$ uv run --frozen --group dev pytest \
    tests/test_codex_startup_visibility.py \
    tests/test_app_server_process_group.py \
    tests/test_app_server_initialize_visibility.py \
    tests/test_task_blocked_initialize_timeout.py \
    tests/test_task_blocked_reason_drift.py \
    tests/test_prose_bound_initialize_timeout.py \
    -v
============================= test session starts ==============================
collected 30 items

tests/test_codex_startup_visibility.py::test_codex_feature_test_failure_fans_out_visibility_degraded PASSED
tests/test_codex_startup_visibility.py::test_codex_register_failure_fans_out_visibility_degraded PASSED
tests/test_app_server_process_group.py::test_app_server_client_starts_in_new_session PASSED
tests/test_app_server_process_group.py::test_app_server_client_terminate_process_group_flag_set PASSED
tests/test_app_server_process_group.py::test_app_server_close_signals_helper_children PASSED
tests/test_app_server_initialize_visibility.py::test_initialize_completed_event_includes_elapsed_and_prompt_size PASSED
tests/test_app_server_initialize_visibility.py::test_initialize_default_timeout_is_90s PASSED
tests/test_app_server_initialize_visibility.py::test_initialize_timeout_env_override PASSED
tests/test_app_server_initialize_visibility.py::test_initialize_progress_events_emitted_during_slow_handshake PASSED
tests/test_app_server_initialize_visibility.py::test_initialize_progress_disabled_when_interval_zero PASSED
tests/test_app_server_initialize_visibility.py::test_initialize_timeout_propagates_underlying_error PASSED
tests/test_task_blocked_initialize_timeout.py::test_initialize_timeout_classified_to_stable_token PASSED
tests/test_task_blocked_initialize_timeout.py::test_initialize_timeout_token_case_insensitive PASSED
tests/test_task_blocked_initialize_timeout.py::test_other_failures_preserve_raw_error_for_now PASSED
tests/test_task_blocked_initialize_timeout.py::test_no_error_falls_back_to_exit_code_summary PASSED
tests/test_task_blocked_initialize_timeout.py::test_initialize_timeout_during_shutdown_uses_distinct_token PASSED
tests/test_task_blocked_initialize_timeout.py::test_both_initialize_tokens_are_in_known_registry PASSED
tests/test_task_blocked_reason_drift.py::test_token_shape_recognises_snake_case PASSED
tests/test_task_blocked_reason_drift.py::test_registered_reason_is_delivered_without_warn PASSED
tests/test_task_blocked_reason_drift.py::test_token_shaped_unregistered_reason_emits_warn_but_delivers PASSED
tests/test_task_blocked_reason_drift.py::test_free_form_prose_reason_is_silent PASSED
tests/test_task_blocked_reason_drift.py::test_registry_includes_both_phase_1_tokens PASSED
tests/test_task_blocked_reason_drift.py::test_recipient_parses_typed_task_blocked_via_discriminator PASSED
tests/test_prose_bound_initialize_timeout.py::test_classify_failure_recognises_initialize_timeout PASSED
tests/test_prose_bound_initialize_timeout.py::test_fallback_message_for_initialize_timeout_is_concise PASSED
tests/test_prose_bound_initialize_timeout.py::test_fallback_message_for_other_classes_keeps_legacy_shape PASSED
tests/test_prose_bound_initialize_timeout.py::test_prose_fallback_emits_typed_visibility_degraded_for_initialize_timeout PASSED
tests/test_prose_bound_initialize_timeout.py::test_prose_fallback_marks_shutdown_request_when_in_progress PASSED
tests/test_prose_bound_initialize_timeout.py::test_prose_fallback_does_not_emit_typed_event_for_other_classes PASSED
tests/test_prose_bound_initialize_timeout.py::test_emit_initialize_timeout_helper_lands_in_lead_inbox PASSED

======================== 30 passed, 1 warning in 3.86s =========================

$ uv run --frozen --group dev pytest -q
1105 passed, 2 deselected, 1 warning in 48.53s

$ test -z "$(git status --short)" && echo "[clean tree]"
[clean tree]
```

Per-file regression count: 2 (codex_startup) + 3 (process_group) +
6 (initialize_visibility) + 6 (task_blocked_initialize_timeout) +
6 (task_blocked_reason_drift) + 7 (prose_bound_initialize_timeout)
= **30 new regression tests across 6 new test files**, plus
adaptations to 5 existing files (test fakes accepting the new
optional `timeout=` kwarg) and 4 watchdog-test ticks lists prepended
with `[0, 0, 0]` for the initialize wrapper's three additional
`time.monotonic()` call sites.

### Wheel-install httpx pin smoke (defends #32 dependency hygiene)

```
$ uv build --wheel
$ ls dist/*.whl
dist/claude_anyteam-0.8.0-py3-none-any.whl
$ uv venv /tmp/wheel-pin-smoke/.venv
$ uv pip install --python /tmp/wheel-pin-smoke/.venv/bin/python \
    dist/claude_anyteam-0.8.0-py3-none-any.whl
$ /tmp/wheel-pin-smoke/.venv/bin/python -c "
import httpx
from packaging.version import Version
v = Version(httpx.__version__)
assert Version('0.28') <= v < Version('1.0'), f'pin violated: {v}'
print(f'PASS: httpx pinned at {httpx.__version__} in [0.28, 1.0)')
import fastmcp; print('fastmcp imports cleanly')
"
PASS: httpx pinned at 0.28.1 in [0.28, 1.0)
fastmcp imports cleanly
```

The pin holds end-to-end on a fresh wheel install. Defends the #32
root-cause failure mode (uv promoting `httpx==1.0.dev3` through the
transitive fastmcp/mcp/httpx-sse chain).

## Design notes

### Token-shape gate on the drift warn

The `KNOWN_TASK_BLOCKED_REASONS` registry plus
`is_token_shaped_reason()` regex (`^[a-z][a-z0-9_]+$`) gating the
wrapper-MCP `send_message` drift warn is deliberate. Rationale:

- `task_blocked.reason` is and stays an open `str` for backward
  compat with existing free-form values like
  `"codex invocation crashed: BrokenPipeError(...)"` or
  `"plan generation failed twice (codex --output-schema produced no
  schema-conformant result)"`. Those reasons are prose, not
  discriminators — they should not be candidates for the registry,
  and warning on them would surface non-drift as drift.
- The registry concept applies to **stable machine-readable
  discriminators** that peers might filter on. Free-form prose is
  legal and unmolested; only token-shaped values (snake_case
  identifiers) get policed.
- Per `feedback_cost_relocation_not_count`: strict-warn-on-everything
  would inflate the warn-event count without inflating the meaningful
  drift signal. The shape gate keeps the visibility_degraded warn
  channel high-signal.
- Per CLAUDE.md §3 (peer efficiency): "idle noise crowding out signal"
  is itself an anti-pattern. The gate keeps the channel substantive.

The graduated-enforcement ladder
(`feedback_graduated_enforcement_ladder`) maps to: rung 1 = declare
registry; rung 2 = surface unregistered token-shaped values via warn.
Rung 3 (action-force / reject) is intentionally deferred to a future
PR when drift data justifies promotion.

### Why Phase 1 ships even with Phase 2 unresolved

The reframed #40 is "second-or-later codex app-server cold-start
within a long-lived wrapper hangs at initialize for 600s — even on
the smallest possible input (shutdown_request)." Without root-cause
fix, the user re-experiences 10 minutes of opaque silence followed
by an apologetic prose_reply. Phase 1 is the §2 visibility-parity
floor: drop the silence to 90s, emit progress events at 30s
intervals, replace the apologetic prose with a typed event the
lead's event log surfaces immediately. Even if root-cause is in
upstream Codex CLI and we cannot patch it directly, Phase 1 gives
the lead enough structured signal to act on.

The `AppServerClient` process-group teardown ships as defensive
hardening — `start_new_session=True` plus `terminate_process_group=True`
is the right teardown convention regardless of root cause and matches
the gemini ACP convention. Diagnostic captures from a confirmed
reproduction (see "Phase 2 status" below) ruled out helper-subprocess
leaks as the actual root cause: only stdio fds were open on the hung
codex app-server (no leaked sockets, no helper children). The
process-group fix stays in scope as a forward-looking guard for the
class of problem; the regression tests pin the behavior.

## Phase 2 status (24h cap)

Phase 2 — root-cause for the second-or-later cold-start hang —
remains open at reduced scope. **A reproduction landed during the
PR-staging window with diagnostic captures that point at a different
root cause than the original "wrapper-state poisoning / process-group
leak" hypothesis.**

**Empirical state at the hang** (PID 123550, codex rust binary):

- 84-105% CPU sustained for the full 600s window
- 28 of 29 threads on `futex_wait_queue`, 1 running — heavy futex
  contention
- Only 3 fds open: stdin/stdout/stderr pipes. **No network sockets.
  No helper subprocesses. No claude-anyteam wrapper sockets.** The
  process-group leak hypothesis is empirically falsified by this
  alone.
- `lsof` diff between T+0 and T+30s shows the only files growing
  during the hang are `~/.codex/logs_2.sqlite-wal` and
  `~/.codex/logs_2.sqlite-shm` (WAL grew 13MB → 39MB in 30s, ~870KB/s).

**Smoking-gun finding**:

- `~/.codex/logs_2.sqlite` = **26GB**
- `~/.codex/logs_2.sqlite-wal` = **2.9GB**
- `~/.codex/` total = **32GB**

**Updated hypothesis**: when codex app-server starts, it opens the
shared global sqlite log in WAL mode. With 2.9GB of accumulated WAL
plus 26GB main DB, SQLite has to do massive checkpoint/recovery work
on connect. The main thread is stuck in WAL processing while the
JSON-RPC `initialize` handshake never gets serviced. This explains:

- 100% sustained CPU during 600s window (sqlite checkpoint is
  CPU-bound)
- "First cold-start sometimes works" depends on whether WAL was
  recently checkpointed
- "Second cold-start consistently hangs" — after the first cold start,
  WAL grows, increasing checkpoint cost
- "Shutdown turn also hangs" — every new app-server has to open the
  bloated log

**Implications**:

1. This is an **upstream codex CLI** failure mode (codex's own log
   substrate, not anything claude-anyteam wraps). Phase 2 cannot
   "fix the leak" because the bug is in codex's WAL handling.
2. Phase 1 §2 wins remain load-bearing — they make the failure mode
   observable to the lead regardless of root cause. 90s timeout +
   typed progress events + typed task_blocked + drift warn ship as
   the §2 visibility floor.
3. **Wrapper-side mitigation candidates** for a follow-up issue:
   - Pre-spawn check that warns on
     `~/.codex/logs_*.sqlite-wal` size beyond a threshold
   - Periodic WAL checkpoint via a direct sqlite3 connection
     before app-server start
   - Redirect codex log to a per-session location via env
     (`CODEX_LOG_DIR` or similar) so WAL doesn't compound across
     sessions
   - Workaround for the user: `rm ~/.codex/logs_2.sqlite*` clears
     accumulated WAL bloat (after ensuring no codex process is
     writing). Document in operator-troubleshooting.

The 24h cap from the original brief still applies, but the
investigation pivots from "fix the leak" to "confirm WAL bloat
hypothesis + propose wrapper-side mitigations." A follow-up issue
will track the mitigation work; #40 will eventually close on the
mitigation rather than on a direct upstream fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)