### PR TITLE
fix(release): bump to v0.8.2 + remove hardcoded test version literal (fix-forward for v0.8.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Self-hosted marketplace for the claude-anyteam Claude Code plugin.",
-    "version": "0.8.1"
+    "version": "0.8.2"
   },
   "plugins": [
     {
       "name": "claude-anyteam",
       "source": "./",
       "description": "Auto-configures Claude Code to route codex-*, gemini-*, and kimi-* teammates through the claude-anyteam spawn shim.",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "author": {
         "name": "friction-research"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-anyteam",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Claude Code plugin that wires claude-anyteam into agent teams with zero-friction Codex/Gemini/Kimi session setup.",
   "author": {
     "name": "friction-research"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to claude-anyteam are documented here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project uses [Semantic Versioning](https://semver.org/).
 
+## [0.8.2] — 2026-05-04
+
+Patch release shipping the v0.8.1 plugin-manifest lock-step work plus a release-CI fix-forward. v0.8.1's auto-release tagged at the merge commit but the `test` job failed on a hardcoded `assert package['version'] == '0.8.0'` literal in `tests/test_npm_package.py` that the v0.8.1 PR didn't touch (the literal was redundant with two existing lock-step tests, and was missed by my version-string grep because the test file used single-quoted Python literals while the grep regex only covered double-quoted JSON literals). The v0.8.1 tag and GitHub release were deleted; v0.8.2 replays the manifest bumps cleanly with the test fix included.
+
+### Fixed
+
+- **`tests/test_npm_package.py:15`** — removed the hardcoded `assert package['version'] == '0.8.0'`. Version is already locked in step by `tests/test_manifest_versions_locked.py` (four-way) and `test_pyproject_version_matches_npm_version` (two-way) in the same file. The hardcoded literal forced a manual edit on every release and was the proximate cause of the v0.8.1 test failure. Single source of truth for version equality lives in the lock-step tests; this contract test now covers only npm-specific fields (name, bin, scripts, engines, dependencies).
+
+### Carried over from the never-published v0.8.1
+
+- **All four user-facing manifests in lock-step at `0.8.2`** (`npm/package.json`, `pyproject.toml`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`).
+- **Four-way manifest version lock-step in CI** — `.github/workflows/auto-release.yml` now triggers on changes to any of the four manifests and fails the build if any disagree.
+- **`tests/test_manifest_versions_locked.py`** — pytest-time lock-step assertion (defense-in-depth alongside the CI gate).
+
+### Net effect for users
+
+After v0.8.2 ships to npm + PyPI, the marketplace tree at `~/.claude/plugins/marketplaces/claude-anyteam/` will pull manifests advertising 0.8.2. The next `/plugin update claude-anyteam@claude-anyteam` will repin from `cache/.../0.5.0/` to a new `cache/.../0.8.2/` directory containing all 3 skills (including `diagnose`), the manifest-driven `help` skill from PR #41, and every other change shipped between v0.5.0 and now.
+
 ## [0.8.1] — 2026-05-04
 
 Patch release fixing a quiet plugin-marketplace version-drift bug that pinned every user on the marketplace install path to the v0.5.0 skill set. No code-behavior changes; this is pure release-process hardening.

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-anyteam",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Beautiful zero-friction installer for claude-anyteam in Claude Code.",
   "type": "module",
   "bin": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "claude-anyteam"
-version = "0.8.1"
+version = "0.8.2"
 description = "Bring Codex, Gemini, Kimi, and native Claude CLI powered teammates into Claude Code with multi-backend routing."
 requires-python = ">=3.12"
 license = "MIT"

--- a/tests/test_npm_package.py
+++ b/tests/test_npm_package.py
@@ -12,7 +12,13 @@ def test_npm_package_metadata_matches_installer_contract() -> None:
     package = json.loads((NPM_DIR / 'package.json').read_text(encoding='utf-8'))
 
     assert package['name'] == 'claude-anyteam'
-    assert package['version'] == '0.8.0'
+    # The version field is asserted by `tests/test_manifest_versions_locked.py`
+    # (four-way lock-step across npm + pyproject + .claude-plugin/plugin.json
+    # + .claude-plugin/marketplace.json) and `test_pyproject_version_matches_npm_version`
+    # below (pyproject ↔ npm). A hardcoded literal here was redundant and
+    # silently broke v0.8.1 release CI when the bump landed without manually
+    # editing this assertion. Single source of truth lives in the lock-step
+    # tests; this contract test now covers only npm-specific fields.
     assert package['bin']['claude-anyteam-setup'] == 'bin/setup.js'
     assert package['bin']['claude-anyteam'] == 'bin/setup.js'
     assert package['scripts']['postinstall'] == 'node bin/setup.js --postinstall'

--- a/uv.lock
+++ b/uv.lock
@@ -132,7 +132,7 @@ wheels = [
 
 [[package]]
 name = "claude-anyteam"
-version = "0.8.1"
+version = "0.8.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

Fix-forward for the v0.8.1 publish that failed. v0.8.1 was tagged at #44's merge commit (`616f2ec`) but the auto-release `test` job failed on a hardcoded `assert package['version'] == '0.8.0'` literal in `tests/test_npm_package.py:15` that #44 didn't touch. The literal was redundant with two existing lock-step assertions (caught only because my version-string grep used double-quote regex while the test used single-quoted Python literals). Tag and GitHub release for v0.8.1 have been deleted; this PR replays the manifest bumps cleanly at v0.8.2 with the test fix included.

## What changed

1. **Remove the hardcoded version literal** (`tests/test_npm_package.py:15`). The version field is already locked in step by:
   - `tests/test_manifest_versions_locked.py::test_all_manifests_agree_on_version` (four-way: npm + pyproject + plugin.json + marketplace.json — landed in #44)
   - `tests/test_npm_package.py::test_pyproject_version_matches_npm_version` (existing two-way: pyproject ↔ npm)

   The hardcoded literal forced a manual edit on every release. Removed; the contract test now covers only npm-specific fields.

2. **Bump all four manifests + uv.lock from `0.8.1` → `0.8.2`**. The auto-release workflow only fires on changes to the four trigger paths; without a bump on this PR, no publish would trigger. v0.8.1 was a never-published version (tag and release deleted from origin) so the next live version is 0.8.2.

3. **CHANGELOG `[0.8.2]` entry** explaining the chain (v0.8.1 manifest-lock-step work + this PR's fix-forward).

## Empirical evidence

### Environment

```
HEAD: 43ca038 (commit on fix/test-npm-package-version-deduplication, parent 616f2ec = main = v0.8.1 tag at this commit was deleted from remote)
Branch: fix/test-npm-package-version-deduplication
Python: 3.12.3
pytest: 9.0.3
uv: 0.11.7
Diff: 7 files changed, 31 insertions(+), 7 deletions(-)
```

### All four manifests at 0.8.2 (lock-step)

```
$ grep -E '^version|"version"' pyproject.toml npm/package.json .claude-plugin/plugin.json .claude-plugin/marketplace.json
pyproject.toml:version = "0.8.2"
npm/package.json:  "version": "0.8.2",
.claude-plugin/plugin.json:  "version": "0.8.2",
.claude-plugin/marketplace.json:    "version": "0.8.2"
.claude-plugin/marketplace.json:      "version": "0.8.2",
```

### Lock-step + npm-package + packaged-schemas tests pass on the bumped state

````
$ git status --short && git rev-parse HEAD && uv run --frozen pytest tests/test_manifest_versions_locked.py tests/test_npm_package.py tests/test_packaged_schemas.py -q --tb=short
43ca038...
............                                                             [100%]
12 passed in 1.31s
````

### Full pytest sweep on the previous commit (510accf, before the bump-to-0.8.2 change)

````
$ uv run --frozen pytest -q --tb=line
1112 passed, 2 deselected, 1 warning in 43.78s
````

(Wider sweep was run on `510accf` which had the test fix without the bump — same code-behavior delta as this commit, just at version 0.8.1 instead of 0.8.2. Re-running on `43ca038` would burn another ~45s without changing the result.)

## What happens after merge

1. Auto-release workflow fires (manifest paths changed).
2. Four-way lock-step check passes (all at 0.8.2).
3. `maybe-tag` creates the v0.8.2 tag at the merge commit.
4. `test` job runs the full pytest sweep — passes (the hardcoded literal that broke v0.8.1's run is gone).
5. `publish-npm` and `publish-pypi` succeed.
6. Marketplace tree at `~/.claude/plugins/marketplaces/claude-anyteam/` pulls the v0.8.2 manifests on its next refresh.
7. `/plugin update claude-anyteam@claude-anyteam` finally repins from `cache/.../0.5.0/` to a new `cache/.../0.8.2/` directory containing the `diagnose` skill, the manifest-driven `help` skill from #41, etc.

## Files changed

```
 .claude-plugin/marketplace.json |  4 ++--
 .claude-plugin/plugin.json      |  2 +-
 CHANGELOG.md                    | 18 ++++++++++++++++++
 npm/package.json                |  2 +-
 pyproject.toml                  |  2 +-
 tests/test_npm_package.py       |  8 +++++++-
 uv.lock                         |  2 +-
 7 files changed, 31 insertions(+), 7 deletions(-)
```

## Test plan

- [x] `pytest tests/test_manifest_versions_locked.py tests/test_npm_package.py tests/test_packaged_schemas.py -q` — 12/12 pass on clean tree at HEAD `43ca038`
- [x] All four manifests verified equal at `0.8.2`
- [x] uv.lock auto-updated to 0.8.2 via `uv lock`
- [x] Full pytest sweep on the test-fix-only state (`510accf`) — 1112 passed, 2 deselected
- [ ] Auto-release workflow tags v0.8.2 and publishes to npm + PyPI (will be observed post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
