### PR TITLE
fix(#43): wrapper-side mitigation for codex sqlite WAL bloat

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -162,6 +162,14 @@ The report combines `team-roster --json`, the rich manifest cache under `~/.clau
 
 `claude-anyteam diagnose` is read-only by default. The only mutating option is `--instrument-spawn`, which writes `env.CLAUDE_ANYTEAM_WRAPPER_MCP_DIAGNOSTICS=1` to `~/.claude/settings.json` so the next teammate spawn captures wrapper MCP diagnostics; use it only when the user explicitly asks to enable instrumentation.
 
+For Codex App Server initialize hangs that mention sqlite/WAL bloat (#43), run:
+
+```bash
+claude-anyteam diagnose --codex-log-bloat
+```
+
+This scans Codex's sqlite home (`CODEX_SQLITE_HOME`, else `CODEX_HOME`, else `~/.codex`) for `logs_*.sqlite-wal` files over the 100 MiB warning threshold. At runtime, claude-anyteam emits a typed `visibility_degraded` warning before spawning `codex app-server` when the threshold is exceeded and attempts a bounded `PRAGMA wal_checkpoint(TRUNCATE)` through sqlite's locking API; it never deletes Codex-owned log files directly.
+
 ## Shim configuration
 
 | Variable | Purpose |

--- a/src/claude_anyteam/app_server.py
+++ b/src/claude_anyteam/app_server.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Callable
 
 from . import logger
 from .jsonrpc_stdio import JsonRpcStdioClient, JsonRpcStdioError
@@ -19,9 +19,11 @@ class AppServerClient(JsonRpcStdioClient):
         codex_binary: str = "codex",
         extra_args: list[str] | None = None,
         env: dict[str, str] | None = None,
+        pre_start_hook: Callable[[], None] | None = None,
     ) -> None:
         self._codex_binary = codex_binary
         self._extra_args = list(extra_args or [])
+        self._pre_start_hook = pre_start_hook
         super().__init__(
             argv=[codex_binary, "app-server", *self._extra_args],
             env=env,
@@ -43,6 +45,13 @@ class AppServerClient(JsonRpcStdioClient):
         )
         self._error_cls = AppServerError
         self.last_thread_result: dict[str, Any] | None = None
+
+    def start(self) -> None:
+        """Start the child process after any wrapper-side preflight hook."""
+
+        if self._pre_start_hook is not None:
+            self._pre_start_hook()
+        super().start()
 
     # ---- transport health / restart ---------------------------------------
 

--- a/src/claude_anyteam/cli.py
+++ b/src/claude_anyteam/cli.py
@@ -170,7 +170,7 @@ def _build_run_parser() -> argparse.ArgumentParser:
             "  claude-anyteam team-roster  Print one-line-per-member team summary (flags ghosts and dead-pane members)\n"
             "  claude-anyteam team-config  Print resolved spawn-time config for a teammate (host model + adapter overrides)\n"
             "  claude-anyteam team-prune-dead  Remove members whose backing tmux pane is gone (use --yes to apply)\n"
-            "  claude-anyteam diagnose     Inspect substrate state: roster, manifests, visibility, wrapper MCP diagnostics\n"
+            "  claude-anyteam diagnose     Inspect substrate state; use --codex-log-bloat for Codex sqlite WAL checks\n"
             "  claude-anyteam status       One-screen team snapshot — roster, adapter overrides, incidents, last activity\n"
             "  claude-anyteam visibility-tail  Follow the live VisibilityEvent JSONL stream"
         ),

--- a/src/claude_anyteam/codex.py
+++ b/src/claude_anyteam/codex.py
@@ -49,6 +49,10 @@ from .env import (
     identity_env,
     env_first,
 )
+from .codex_log_bloat import (
+    checkpoint_bloated_codex_wals,
+    inspect_codex_log_bloat,
+)
 from .headless_visibility import HeadlessTurnVisibility, coerce_stream_text
 from .messages import VisibilityEvent
 from .prompts import TEAM_MESSAGING_BLOCK
@@ -1535,6 +1539,7 @@ def app_server_invoke(
     client = AppServerClient(
         codex_binary=codex_binary,
         env=identity_env(os.environ, team=settings_team, name=settings_agent),
+        pre_start_hook=lambda: _codex_log_bloat_pre_spawn(),
     )
 
     events: list[dict[str, Any]] = []
@@ -1611,6 +1616,84 @@ def app_server_invoke(
                     error=str(e),
                 )
         return event
+
+    def _codex_log_bloat_pre_spawn() -> None:
+        """Emit #43 pre-spawn visibility and run a bounded WAL checkpoint."""
+
+        try:
+            report = inspect_codex_log_bloat(env=os.environ)
+        except Exception as e:
+            logger.debug("codex.sqlite_wal_bloat.inspect_failed", error=str(e))
+            return
+        if not report.is_bloated:
+            return
+
+        report_payload = report.to_dict()
+        _emit_visibility_event(
+            kind="visibility_degraded",
+            severity="warn",
+            summary=(
+                "Codex sqlite WAL bloat detected before App Server spawn; "
+                "initialize may be delayed"
+            ),
+            visibility={
+                "mailbox": False,
+                "task_state": False,
+                "event_log": True,
+                "stderr": True,
+            },
+            payload={
+                "surface": "codex_sqlite_wal_bloat",
+                "action": "bounded_checkpoint_before_spawn",
+                "diagnose_command": "claude-anyteam diagnose --codex-log-bloat",
+                **report_payload,
+            },
+        )
+
+        try:
+            checkpoint_results = checkpoint_bloated_codex_wals(report, env=os.environ)
+        except Exception as e:
+            logger.debug("codex.sqlite_wal_bloat.checkpoint_failed", error=str(e))
+            return
+        if not checkpoint_results:
+            return
+        checkpoint_payload = {
+            "surface": "codex_sqlite_wal_checkpoint",
+            "results": [row.to_dict() for row in checkpoint_results],
+        }
+        all_ok = all(row.ok for row in checkpoint_results if row.attempted)
+        any_attempted = any(row.attempted for row in checkpoint_results)
+        if not any_attempted:
+            return
+        if all_ok:
+            _emit_visibility_event(
+                kind="turn_progress",
+                severity="info",
+                summary="Codex sqlite WAL checkpoint completed before spawn",
+                visibility={
+                    "mailbox": False,
+                    "task_state": False,
+                    "event_log": True,
+                    "stderr": True,
+                },
+                payload=checkpoint_payload,
+            )
+        else:
+            _emit_visibility_event(
+                kind="visibility_degraded",
+                severity="warn",
+                summary=(
+                    "Codex sqlite WAL checkpoint did not complete before "
+                    "App Server spawn"
+                ),
+                visibility={
+                    "mailbox": False,
+                    "task_state": False,
+                    "event_log": True,
+                    "stderr": True,
+                },
+                payload=checkpoint_payload,
+            )
 
     def _record(ev: dict[str, Any]) -> None:
         nonlocal tool_call_events

--- a/src/claude_anyteam/codex_log_bloat.py
+++ b/src/claude_anyteam/codex_log_bloat.py
@@ -1,0 +1,417 @@
+"""Detection and bounded mitigation for Codex CLI sqlite WAL bloat.
+
+Codex CLI stores its trace/state sqlite databases under the Codex sqlite home
+(defaulting to ``~/.codex``). Issue #43 tracks an upstream failure mode where
+``logs_*.sqlite-wal`` can grow large enough that ``codex app-server`` spends
+its JSON-RPC initialize budget inside sqlite WAL recovery/checkpoint work.
+
+This module keeps the claude-anyteam side small and harness-preserving:
+we inspect Codex-owned files, emit typed visibility when they look dangerous,
+and optionally ask sqlite to checkpoint through the public database API. We do
+not delete, rotate, or rewrite Codex logs directly.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+CODEX_HOME_ENV = "CODEX_HOME"
+CODEX_SQLITE_HOME_ENV = "CODEX_SQLITE_HOME"
+
+CODEX_WAL_WARN_THRESHOLD_BYTES_ENV = (
+    "CLAUDE_ANYTEAM_CODEX_SQLITE_WAL_WARN_THRESHOLD_BYTES"
+)
+CODEX_WAL_CHECKPOINT_ENV = "CLAUDE_ANYTEAM_CODEX_SQLITE_WAL_CHECKPOINT"
+CODEX_WAL_CHECKPOINT_TIMEOUT_ENV = (
+    "CLAUDE_ANYTEAM_CODEX_SQLITE_WAL_CHECKPOINT_TIMEOUT_S"
+)
+
+DEFAULT_CODEX_WAL_WARN_THRESHOLD_BYTES = 100 * 1024 * 1024
+DEFAULT_CODEX_WAL_CHECKPOINT_TIMEOUT_S = 10.0
+LOGS_WAL_GLOB = "logs_*.sqlite-wal"
+
+_FALSEY = {"0", "false", "no", "off", "disabled"}
+
+
+@dataclass(frozen=True)
+class CodexWalFile:
+    """One Codex ``logs_*.sqlite-wal`` file and its adjacent sqlite files."""
+
+    path: Path
+    size_bytes: int
+    threshold_bytes: int
+    database_path: Path
+    database_size_bytes: int | None = None
+    shm_path: Path | None = None
+    shm_size_bytes: int | None = None
+
+    @property
+    def exceeds_threshold(self) -> bool:
+        return self.size_bytes > self.threshold_bytes
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "path": str(self.path),
+            "size_bytes": self.size_bytes,
+            "size_mib": round(self.size_bytes / (1024 * 1024), 2),
+            "threshold_bytes": self.threshold_bytes,
+            "threshold_mib": round(self.threshold_bytes / (1024 * 1024), 2),
+            "exceeds_threshold": self.exceeds_threshold,
+            "database_path": str(self.database_path),
+            "database_size_bytes": self.database_size_bytes,
+            "database_size_mib": (
+                round(self.database_size_bytes / (1024 * 1024), 2)
+                if self.database_size_bytes is not None
+                else None
+            ),
+            "shm_path": str(self.shm_path) if self.shm_path is not None else None,
+            "shm_size_bytes": self.shm_size_bytes,
+        }
+
+
+@dataclass(frozen=True)
+class CodexLogBloatReport:
+    sqlite_home: Path
+    sqlite_home_source: str
+    threshold_bytes: int
+    wal_files: tuple[CodexWalFile, ...]
+
+    @property
+    def bloated_wal_files(self) -> tuple[CodexWalFile, ...]:
+        return tuple(row for row in self.wal_files if row.exceeds_threshold)
+
+    @property
+    def is_bloated(self) -> bool:
+        return bool(self.bloated_wal_files)
+
+    @property
+    def max_wal_bytes(self) -> int:
+        return max((row.size_bytes for row in self.wal_files), default=0)
+
+    @property
+    def total_wal_bytes(self) -> int:
+        return sum(row.size_bytes for row in self.wal_files)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "sqlite_home": str(self.sqlite_home),
+            "sqlite_home_source": self.sqlite_home_source,
+            "threshold_bytes": self.threshold_bytes,
+            "threshold_mib": round(self.threshold_bytes / (1024 * 1024), 2),
+            "status": "bloated" if self.is_bloated else "ok",
+            "wal_file_count": len(self.wal_files),
+            "bloated_wal_file_count": len(self.bloated_wal_files),
+            "total_wal_bytes": self.total_wal_bytes,
+            "total_wal_mib": round(self.total_wal_bytes / (1024 * 1024), 2),
+            "max_wal_bytes": self.max_wal_bytes,
+            "max_wal_mib": round(self.max_wal_bytes / (1024 * 1024), 2),
+            "wal_files": [row.to_dict() for row in self.wal_files],
+            "bloated_wal_files": [row.to_dict() for row in self.bloated_wal_files],
+        }
+
+
+@dataclass(frozen=True)
+class CodexWalCheckpointResult:
+    wal_path: Path
+    database_path: Path
+    attempted: bool
+    status: str
+    duration_ms: int = 0
+    busy: int | None = None
+    log_frames: int | None = None
+    checkpointed_frames: int | None = None
+    error: str | None = None
+
+    @property
+    def ok(self) -> bool:
+        return self.status in {"checkpointed", "no_wal"}
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "wal_path": str(self.wal_path),
+            "database_path": str(self.database_path),
+            "attempted": self.attempted,
+            "status": self.status,
+            "duration_ms": self.duration_ms,
+            "busy": self.busy,
+            "log_frames": self.log_frames,
+            "checkpointed_frames": self.checkpointed_frames,
+            "error": self.error,
+        }
+
+
+def _truthy_env_enabled(env: Mapping[str, str], name: str, *, default: bool) -> bool:
+    raw = env.get(name)
+    if raw is None or raw == "":
+        return default
+    return raw.strip().lower() not in _FALSEY
+
+
+def _int_env(env: Mapping[str, str], name: str, default: int) -> int:
+    raw = env.get(name)
+    if raw is None or raw == "":
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    return max(0, value)
+
+
+def _float_env(env: Mapping[str, str], name: str, default: float) -> float:
+    raw = env.get(name)
+    if raw is None or raw == "":
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        return default
+    return max(0.001, value)
+
+
+def codex_sqlite_home(
+    env: Mapping[str, str] | None = None,
+    *,
+    home: Path | None = None,
+) -> tuple[Path, str]:
+    """Return the Codex sqlite directory and the source used to derive it.
+
+    Empirical Codex CLI 0.128.0 behavior: ``CODEX_SQLITE_HOME`` redirects
+    sqlite files; otherwise ``CODEX_HOME`` redirects the whole Codex home;
+    otherwise sqlite files live in ``~/.codex``. ``CODEX_SQLITE_HOME`` is not
+    a log-only redirect (it also moves state sqlite DBs), so claude-anyteam
+    treats it as an operator setting to observe rather than forcing it for
+    teammates.
+    """
+
+    env_map = env if env is not None else os.environ
+    raw = env_map.get(CODEX_SQLITE_HOME_ENV)
+    if raw:
+        return Path(raw).expanduser(), CODEX_SQLITE_HOME_ENV
+    raw = env_map.get(CODEX_HOME_ENV)
+    if raw:
+        return Path(raw).expanduser(), CODEX_HOME_ENV
+    root = home if home is not None else Path.home()
+    return root / ".codex", "default"
+
+
+def codex_wal_warn_threshold_bytes(env: Mapping[str, str] | None = None) -> int:
+    env_map = env if env is not None else os.environ
+    return _int_env(
+        env_map,
+        CODEX_WAL_WARN_THRESHOLD_BYTES_ENV,
+        DEFAULT_CODEX_WAL_WARN_THRESHOLD_BYTES,
+    )
+
+
+def inspect_codex_log_bloat(
+    *,
+    sqlite_home: Path | None = None,
+    env: Mapping[str, str] | None = None,
+    threshold_bytes: int | None = None,
+) -> CodexLogBloatReport:
+    """Stat Codex ``logs_*.sqlite-wal`` files without mutating them."""
+
+    env_map = env if env is not None else os.environ
+    if sqlite_home is None:
+        sqlite_home, source = codex_sqlite_home(env_map)
+    else:
+        source = "explicit"
+    threshold = (
+        codex_wal_warn_threshold_bytes(env_map)
+        if threshold_bytes is None
+        else max(0, int(threshold_bytes))
+    )
+    rows: list[CodexWalFile] = []
+    try:
+        paths = sorted(sqlite_home.glob(LOGS_WAL_GLOB))
+    except OSError:
+        paths = []
+    for wal_path in paths:
+        try:
+            size = wal_path.stat().st_size
+        except OSError:
+            continue
+        # Strip only the trailing WAL marker: ``Path.with_suffix("")`` would
+        # turn ``logs_2.sqlite-wal`` into ``logs_2`` because pathlib treats
+        # ``.sqlite-wal`` as one suffix.
+        database_path = Path(str(wal_path)[:-4])
+        shm_path = database_path.with_name(database_path.name + "-shm")
+        try:
+            db_size = database_path.stat().st_size
+        except OSError:
+            db_size = None
+        try:
+            shm_size = shm_path.stat().st_size
+        except OSError:
+            shm_size = None
+            shm_path_for_row: Path | None = None
+        else:
+            shm_path_for_row = shm_path
+        rows.append(
+            CodexWalFile(
+                path=wal_path,
+                size_bytes=size,
+                threshold_bytes=threshold,
+                database_path=database_path,
+                database_size_bytes=db_size,
+                shm_path=shm_path_for_row,
+                shm_size_bytes=shm_size,
+            )
+        )
+    rows.sort(key=lambda row: row.size_bytes, reverse=True)
+    return CodexLogBloatReport(
+        sqlite_home=sqlite_home,
+        sqlite_home_source=source,
+        threshold_bytes=threshold,
+        wal_files=tuple(rows),
+    )
+
+
+def checkpoint_codex_wal(
+    wal: CodexWalFile,
+    *,
+    timeout_s: float = DEFAULT_CODEX_WAL_CHECKPOINT_TIMEOUT_S,
+) -> CodexWalCheckpointResult:
+    """Run ``PRAGMA wal_checkpoint(TRUNCATE)`` for one Codex log DB.
+
+    Safety stance for Option B (#43): use sqlite's own locking/checkpoint API
+    with a short busy timeout and a progress deadline. If another Codex process
+    is writing, sqlite reports ``busy``/``locked`` and we continue with a typed
+    degraded signal instead of deleting files or waiting unboundedly.
+    """
+
+    started = time.monotonic()
+    db_path = wal.database_path
+    if not db_path.exists():
+        return CodexWalCheckpointResult(
+            wal_path=wal.path,
+            database_path=db_path,
+            attempted=False,
+            status="missing_db",
+            error="database file not found beside WAL",
+        )
+
+    deadline = started + max(0.001, timeout_s)
+    conn: sqlite3.Connection | None = None
+    try:
+        conn = sqlite3.connect(
+            f"file:{db_path}?mode=rw",
+            uri=True,
+            timeout=max(0.001, timeout_s),
+        )
+        conn.execute(f"PRAGMA busy_timeout={int(max(0.001, timeout_s) * 1000)}")
+
+        def _progress() -> int:
+            return 1 if time.monotonic() >= deadline else 0
+
+        conn.set_progress_handler(_progress, 1000)
+        row = conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()
+        duration_ms = int((time.monotonic() - started) * 1000)
+        busy: int | None = None
+        log_frames: int | None = None
+        checkpointed_frames: int | None = None
+        if row is not None and len(row) >= 3:
+            busy, log_frames, checkpointed_frames = (int(row[0]), int(row[1]), int(row[2]))
+        status = "busy" if busy and busy > 0 else "checkpointed"
+        return CodexWalCheckpointResult(
+            wal_path=wal.path,
+            database_path=db_path,
+            attempted=True,
+            status=status,
+            duration_ms=duration_ms,
+            busy=busy,
+            log_frames=log_frames,
+            checkpointed_frames=checkpointed_frames,
+        )
+    except sqlite3.OperationalError as exc:
+        duration_ms = int((time.monotonic() - started) * 1000)
+        message = str(exc)
+        if "interrupted" in message.lower():
+            status = "timeout"
+        elif "locked" in message.lower() or "busy" in message.lower():
+            status = "busy"
+        else:
+            status = "error"
+        return CodexWalCheckpointResult(
+            wal_path=wal.path,
+            database_path=db_path,
+            attempted=True,
+            status=status,
+            duration_ms=duration_ms,
+            error=f"sqlite3.OperationalError: {message}",
+        )
+    except sqlite3.Error as exc:
+        duration_ms = int((time.monotonic() - started) * 1000)
+        return CodexWalCheckpointResult(
+            wal_path=wal.path,
+            database_path=db_path,
+            attempted=True,
+            status="error",
+            duration_ms=duration_ms,
+            error=f"{type(exc).__name__}: {exc}",
+        )
+    finally:
+        if conn is not None:
+            try:
+                conn.close()
+            except sqlite3.Error:
+                pass
+
+
+def checkpoint_bloated_codex_wals(
+    report: CodexLogBloatReport,
+    *,
+    env: Mapping[str, str] | None = None,
+    enabled: bool | None = None,
+    timeout_s: float | None = None,
+) -> tuple[CodexWalCheckpointResult, ...]:
+    """Checkpoint every threshold-exceeding WAL in ``report`` when enabled."""
+
+    env_map = env if env is not None else os.environ
+    should_run = (
+        _truthy_env_enabled(env_map, CODEX_WAL_CHECKPOINT_ENV, default=True)
+        if enabled is None
+        else enabled
+    )
+    if not should_run:
+        return tuple(
+            CodexWalCheckpointResult(
+                wal_path=wal.path,
+                database_path=wal.database_path,
+                attempted=False,
+                status="disabled",
+            )
+            for wal in report.bloated_wal_files
+        )
+    budget = (
+        _float_env(
+            env_map,
+            CODEX_WAL_CHECKPOINT_TIMEOUT_ENV,
+            DEFAULT_CODEX_WAL_CHECKPOINT_TIMEOUT_S,
+        )
+        if timeout_s is None
+        else max(0.001, timeout_s)
+    )
+    return tuple(
+        checkpoint_codex_wal(wal, timeout_s=budget)
+        for wal in report.bloated_wal_files
+    )
+
+
+def format_bytes(num_bytes: int | None) -> str:
+    if num_bytes is None:
+        return "-"
+    value = float(num_bytes)
+    for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
+        if abs(value) < 1024.0 or unit == "TiB":
+            if unit == "B":
+                return f"{int(value)} {unit}"
+            return f"{value:.1f} {unit}"
+        value /= 1024.0
+    return f"{num_bytes} B"

--- a/src/claude_anyteam/diagnose_cli.py
+++ b/src/claude_anyteam/diagnose_cli.py
@@ -26,6 +26,7 @@ from typing import Any, TextIO
 
 from . import team_cli
 from .capabilities import CAPABILITY_HOOKS, CAPABILITY_MANIFEST_VERSION
+from .codex_log_bloat import format_bytes, inspect_codex_log_bloat
 from .env import LEGACY_TEAM_ENV, TEAM_ENV
 
 INSTRUMENT_ENV_KEY = "CLAUDE_ANYTEAM_WRAPPER_MCP_DIAGNOSTICS"
@@ -201,6 +202,18 @@ def _build_parser() -> argparse.ArgumentParser:
     p.add_argument("--since", help="ISO timestamp lower bound for events/diagnostic logs (e.g. 2026-04-28T15:00:00Z).")
     p.add_argument("--limit", type=int, default=10, help="Recent rows per section (default: 10).")
     p.add_argument("--json", action="store_true", help="Emit JSON instead of human-readable report.")
+    p.add_argument(
+        "--codex-log-bloat",
+        action="store_true",
+        help=(
+            "Check Codex CLI logs_*.sqlite-wal size and print the #43 "
+            "operator diagnostic. Does not require --team."
+        ),
+    )
+    p.add_argument(
+        "--codex-sqlite-home",
+        help=argparse.SUPPRESS,
+    )
     p.add_argument(
         "--instrument-spawn",
         action="store_true",
@@ -1049,6 +1062,82 @@ def _render_bundle(report: dict[str, Any], inner: str, args: argparse.Namespace)
 
 
 # --------------------------------------------------------------------------- #
+# Codex sqlite WAL bloat diagnostic (#43)
+# --------------------------------------------------------------------------- #
+
+
+def _build_codex_log_bloat_report(args: argparse.Namespace) -> dict[str, Any]:
+    sqlite_home = (
+        Path(args.codex_sqlite_home).expanduser()
+        if getattr(args, "codex_sqlite_home", None)
+        else None
+    )
+    report = inspect_codex_log_bloat(sqlite_home=sqlite_home)
+    status = "degraded" if report.is_bloated else "ok"
+    return {
+        "schema_version": 1,
+        "mode": "read-only",
+        "status": status,
+        "codex_log_bloat": report.to_dict(),
+        "impact": (
+            "Bloated Codex logs_*.sqlite-wal files can stall `codex app-server` "
+            "before JSON-RPC initialize is serviced."
+        ),
+        "operator_actions": [
+            "Run `claude-anyteam diagnose --codex-log-bloat` to confirm size before a repro.",
+            (
+                "If no Codex process is running, run a sqlite checkpoint or move/remove "
+                "the matching logs_*.sqlite* files after backing them up."
+            ),
+            (
+                "claude-anyteam automatically emits a typed visibility_degraded warning "
+                "and attempts a bounded sqlite checkpoint before Codex App Server spawn."
+            ),
+        ],
+    }
+
+
+def _render_codex_log_bloat_report(report: dict[str, Any]) -> str:
+    data = report.get("codex_log_bloat") or {}
+    lines: list[str] = []
+    lines.append("claude-anyteam diagnose --codex-log-bloat mode=read-only")
+    lines.append(
+        f"sqlite_home={data.get('sqlite_home')} source={data.get('sqlite_home_source')}"
+    )
+    threshold = data.get("threshold_bytes")
+    lines.append(f"threshold={format_bytes(threshold)} ({threshold} bytes)")
+    lines.append("")
+    lines.append("[codex-log-bloat]")
+    lines.append(
+        "status={status} wal_files={files} bloated={bloated} total_wal={total} max_wal={max_wal}".format(
+            status=report.get("status"),
+            files=data.get("wal_file_count", 0),
+            bloated=data.get("bloated_wal_file_count", 0),
+            total=format_bytes(data.get("total_wal_bytes")),
+            max_wal=format_bytes(data.get("max_wal_bytes")),
+        )
+    )
+    wal_files = data.get("wal_files") or []
+    if not wal_files:
+        lines.append("(no logs_*.sqlite-wal files found)")
+    for row in wal_files:
+        state = "BLOATED" if row.get("exceeds_threshold") else "ok"
+        lines.append(
+            f"- {row.get('path')} status={state} wal={format_bytes(row.get('size_bytes'))} "
+            f"db={format_bytes(row.get('database_size_bytes'))}"
+        )
+    lines.append("")
+    if report.get("status") == "degraded":
+        lines.append("impact: " + str(report.get("impact")))
+        lines.append("operator_actions:")
+        for action in report.get("operator_actions") or []:
+            lines.append(f"- {action}")
+    else:
+        lines.append("impact: no threshold-exceeding Codex sqlite WAL files detected")
+    return "\n".join(lines) + "\n"
+
+
+# --------------------------------------------------------------------------- #
 # Main
 # --------------------------------------------------------------------------- #
 
@@ -1062,6 +1151,27 @@ def main(argv: list[str], *, stdout: TextIO | None = None, stderr: TextIO | None
     if args.limit < 0:
         err.write("error: --limit must be >= 0\n")
         return 2
+
+    if args.codex_log_bloat:
+        if args.incident or args.incidents:
+            err.write("error: --codex-log-bloat cannot be combined with incident mode\n")
+            return 2
+        if args.instrument_spawn:
+            err.write("error: --codex-log-bloat cannot be combined with --instrument-spawn\n")
+            return 2
+        if args.bundle:
+            err.write("error: --codex-log-bloat cannot be combined with --bundle\n")
+            return 2
+        try:
+            report = _build_codex_log_bloat_report(args)
+        except (OSError, ValueError) as exc:
+            err.write(f"error: {exc}\n")
+            return 1
+        if args.json:
+            out.write(json.dumps(report, indent=2, sort_keys=True) + "\n")
+        else:
+            out.write(_render_codex_log_bloat_report(report))
+        return 1 if report.get("status") == "degraded" else 0
 
     if args.incident or args.incidents:
         if args.instrument_spawn:

--- a/tests/test_codex_log_bloat.py
+++ b/tests/test_codex_log_bloat.py
@@ -1,0 +1,203 @@
+"""Regression coverage for Codex sqlite WAL-bloat mitigation (#43)."""
+
+from __future__ import annotations
+
+import io
+import json
+import sqlite3
+from pathlib import Path
+from unittest.mock import patch
+
+from claude_anyteam import app_server as app_server_mod
+from claude_anyteam import codex as codex_mod
+from claude_anyteam import diagnose_cli
+from claude_anyteam.codex_log_bloat import (
+    CODEX_WAL_CHECKPOINT_ENV,
+    CODEX_WAL_WARN_THRESHOLD_BYTES_ENV,
+    CodexWalFile,
+    checkpoint_codex_wal,
+    inspect_codex_log_bloat,
+)
+
+
+def _make_sparse_wal(root: Path, *, size_bytes: int, name: str = "logs_2") -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    wal = root / f"{name}.sqlite-wal"
+    with wal.open("wb") as fh:
+        fh.truncate(size_bytes)
+    return wal
+
+
+def test_wal_size_check_flags_sparse_200mb_repro(tmp_path: Path) -> None:
+    """Proof-of-repro unit: a fake 200 MiB Codex WAL is detected as bloated."""
+
+    wal = _make_sparse_wal(tmp_path, size_bytes=200 * 1024 * 1024)
+    (tmp_path / "logs_2.sqlite").write_bytes(b"not a real sqlite db for stat-only repro")
+
+    report = inspect_codex_log_bloat(sqlite_home=tmp_path)
+
+    assert report.is_bloated is True
+    assert report.max_wal_bytes == 200 * 1024 * 1024
+    assert report.bloated_wal_files[0].path == wal
+    assert report.bloated_wal_files[0].database_size_bytes == len(
+        b"not a real sqlite db for stat-only repro"
+    )
+
+
+def test_threshold_env_controls_bloat_boundary(tmp_path: Path, monkeypatch) -> None:
+    _make_sparse_wal(tmp_path, size_bytes=2 * 1024 * 1024)
+    monkeypatch.setenv(CODEX_WAL_WARN_THRESHOLD_BYTES_ENV, str(3 * 1024 * 1024))
+
+    below = inspect_codex_log_bloat(sqlite_home=tmp_path)
+    assert below.is_bloated is False
+
+    monkeypatch.setenv(CODEX_WAL_WARN_THRESHOLD_BYTES_ENV, str(1024 * 1024))
+    above = inspect_codex_log_bloat(sqlite_home=tmp_path)
+    assert above.is_bloated is True
+
+
+def test_diagnose_codex_log_bloat_subcommand_flags_large_wal(tmp_path: Path) -> None:
+    _make_sparse_wal(tmp_path, size_bytes=200 * 1024 * 1024)
+    out = io.StringIO()
+    err = io.StringIO()
+
+    rc = diagnose_cli.main(
+        ["--codex-log-bloat", "--codex-sqlite-home", str(tmp_path), "--json"],
+        stdout=out,
+        stderr=err,
+    )
+
+    assert rc == 1
+    assert err.getvalue() == ""
+    payload = json.loads(out.getvalue())
+    assert payload["status"] == "degraded"
+    details = payload["codex_log_bloat"]
+    assert details["bloated_wal_file_count"] == 1
+    assert details["max_wal_bytes"] == 200 * 1024 * 1024
+    assert "codex app-server" in payload["impact"]
+
+
+def test_diagnose_codex_log_bloat_subcommand_reports_ok_without_wal(tmp_path: Path) -> None:
+    out = io.StringIO()
+
+    rc = diagnose_cli.main(
+        ["--codex-log-bloat", "--codex-sqlite-home", str(tmp_path)],
+        stdout=out,
+        stderr=io.StringIO(),
+    )
+
+    assert rc == 0
+    body = out.getvalue()
+    assert "status=ok" in body
+    assert "no logs_*.sqlite-wal files found" in body
+
+
+def test_checkpoint_path_truncates_real_sqlite_wal(tmp_path: Path) -> None:
+    """Option B proof: use sqlite's API to drain a real WAL safely."""
+
+    db = tmp_path / "logs_2.sqlite"
+    conn = sqlite3.connect(db)
+    try:
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA wal_autocheckpoint=0")
+        conn.execute("CREATE TABLE events(id INTEGER PRIMARY KEY, body TEXT)")
+        conn.executemany(
+            "INSERT INTO events(body) VALUES (?)",
+            [("x" * 1024,) for _ in range(256)],
+        )
+        conn.commit()
+        wal_path = Path(str(db) + "-wal")
+        assert wal_path.exists(), "test setup failed to create a WAL file"
+        assert wal_path.stat().st_size > 0
+
+        result = checkpoint_codex_wal(
+            CodexWalFile(
+                path=wal_path,
+                size_bytes=wal_path.stat().st_size,
+                threshold_bytes=1,
+                database_path=db,
+            ),
+            timeout_s=5,
+        )
+    finally:
+        conn.close()
+
+    assert result.attempted is True
+    assert result.status == "checkpointed"
+    assert result.error is None
+    assert (not wal_path.exists()) or wal_path.stat().st_size == 0
+
+
+def test_pre_spawn_warning_emits_visibility_degraded_before_initialize(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Proof-of-fix unit: app_server_invoke warns before initialize starts."""
+
+    _make_sparse_wal(tmp_path, size_bytes=200 * 1024 * 1024)
+    monkeypatch.setenv("CODEX_SQLITE_HOME", str(tmp_path))
+    monkeypatch.setenv(CODEX_WAL_CHECKPOINT_ENV, "0")
+
+    captured = []
+
+    class _Queue:
+        def __init__(self) -> None:
+            self._items = [
+                {"method": "turn/completed", "params": {"turn": {"status": "ok"}}}
+            ]
+
+        def get(self, timeout=None):
+            if self._items:
+                return self._items.pop(0)
+            raise RuntimeError("empty (test)")
+
+    class _FakeClient:
+        notifications = _Queue()
+
+        def __init__(self, *args, pre_start_hook=None, **kwargs) -> None:
+            self._pre_start_hook = pre_start_hook
+            self.notifications = _Queue()
+
+        def start(self) -> None:
+            if self._pre_start_hook is not None:
+                self._pre_start_hook()
+
+        def initialize(self, **_kwargs):
+            return {}
+
+        def thread_start(self, **kwargs):
+            return "thread-id"
+
+        def turn_start(self, **kwargs):
+            return "turn-id"
+
+        def drain_notifications(self):
+            return []
+
+        def turn_interrupt(self, **kwargs):
+            pass
+
+        def close(self, **kwargs):
+            pass
+
+    with patch.object(app_server_mod, "AppServerClient", _FakeClient):
+        result = codex_mod.app_server_invoke(
+            task_prompt="noop",
+            cwd=tmp_path,
+            schema=None,
+            settings_team="team",
+            settings_agent="codex-a",
+            event_sink=captured.append,
+        )
+
+    assert result.exit_code == 0
+    surfaces = [event.payload.get("surface") for event in captured]
+    assert surfaces[0] == "codex_sqlite_wal_bloat"
+    warning = captured[0]
+    assert warning.kind == "visibility_degraded"
+    assert warning.severity == "warn"
+    assert warning.payload["max_wal_bytes"] == 200 * 1024 * 1024
+    completed_index = next(
+        i for i, event in enumerate(captured) if event.kind == "app_server_initialize_completed"
+    )
+    assert completed_index > 0


### PR DESCRIPTION
## Summary

- add `claude_anyteam.codex_log_bloat` to stat Codex `logs_*.sqlite-wal`, apply the 100 MiB threshold, and run bounded `PRAGMA wal_checkpoint(TRUNCATE)` through sqlite locking APIs
- emit a pre-spawn typed `visibility_degraded` warning before every Codex App Server child start when WAL bloat is detected
- add `claude-anyteam diagnose --codex-log-bloat` plus docs/tests for the operator-facing diagnostic

## Investigation notes

- `codex --help` / `codex app-server --help` do not advertise a log-only redirect such as `CODEX_LOG_DIR`.
- Codex 0.128.0 does honor `CODEX_SQLITE_HOME`, but empirical launch with a temp home created both `logs_2.sqlite` and `state_5.sqlite` there. Because that is an all-sqlite-home redirect rather than a log-only redirect, this PR does not force it for teammates (preserves Codex harness state semantics). The diagnostic observes `CODEX_SQLITE_HOME` when the operator sets it.

## Proof of repro

Simulated the issue in a temp Codex sqlite home without touching the user's real `~/.codex`:

```text
$ truncate -s 200M "$tmp/logs_2.sqlite-wal"
$ uv run claude-anyteam diagnose --codex-log-bloat --codex-sqlite-home "$tmp"
claude-anyteam diagnose --codex-log-bloat mode=read-only
sqlite_home=/tmp/tmp.ePKENaDKWc source=explicit
threshold=100.0 MiB (104857600 bytes)

[codex-log-bloat]
status=degraded wal_files=1 bloated=1 total_wal=200.0 MiB max_wal=200.0 MiB
- /tmp/tmp.ePKENaDKWc/logs_2.sqlite-wal status=BLOATED wal=200.0 MiB db=-
```

Pre-fix sequence was the #40/#43 failure shape: no bloat-specific event before initialize progress/timeout:

```text
codex_app_server_mcp_config_prepared
app_server_initialize_progress ...
app_server_initialize_progress ...
turn_failed: JSON-RPC stdio process did not respond to initialize within 90.0s
```

## Proof of fix

With the same fake 200 MiB WAL pointed at `CODEX_SQLITE_HOME`, the pre-spawn hook fires before initialize:

```text
visibility_degraded severity=warn surface=codex_sqlite_wal_bloat max_wal_bytes=209715200 summary=Codex sqlite WAL bloat detected before App Server spawn; initialize may be delayed
app_server_initialize_completed severity=info surface=None max_wal_bytes=None summary=Codex App Server initialize completed in 0ms
turn_started severity=info surface=None max_wal_bytes=None summary=Codex App Server turn started
turn_completed severity=info surface=None max_wal_bytes=None summary=Codex App Server turn completed
```

The checkpoint path is covered with a real sqlite WAL fixture; it runs `PRAGMA wal_checkpoint(TRUNCATE)` and verifies the WAL is drained/deleted without direct file deletion.

## Tests

```text
uv run pytest -q tests/test_codex_log_bloat.py tests/test_app_server_mcp_config.py tests/test_app_server_initialize_visibility.py tests/test_diagnose_cli.py
25 passed in 1.50s

uv run pytest -q
1140 passed, 11 skipped, 2 deselected, 1 warning in 145.61s (0:02:25)
```

Fixes #43
