### PR TITLE
fix(#40): phase 2 codex app-server cold-start mitigation

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -75,6 +75,11 @@ Every flag has an equivalent env var:
 | `CLAUDE_ANYTEAM_EFFORT` | `--effort` |
 | `CLAUDE_ANYTEAM_PLAN_MODE` | `--plan-mode` (set to `true`) |
 | `CLAUDE_ANYTEAM_APP_SERVER` | set `false` to match `--no-app-server` |
+| `CLAUDE_ANYTEAM_APP_SERVER_START_GATE` | set `0`/`false` to disable the #40 Codex App Server cold-start gate |
+| `CLAUDE_ANYTEAM_APP_SERVER_START_GATE_JITTER_S` | max randomized pre-start jitter for concurrent Codex App Server spawns (default `0.25`) |
+| `CLAUDE_ANYTEAM_APP_SERVER_START_GATE_COOLDOWN_S` | short post-start serialization window before another Codex App Server spawn proceeds (default `0.25`) |
+| `CLAUDE_ANYTEAM_APP_SERVER_INITIALIZE_RETRIES` | retry count for Codex App Server initialize timeouts before surfacing failure (default `1`) |
+| `CLAUDE_ANYTEAM_APP_SERVER_INITIALIZE_RETRY_BACKOFF_S` | backoff before the initialize retry (default `2.0`) |
 | `CLAUDE_ANYTEAM_POLL_S` | `--poll-s` |
 | `CLAUDE_ANYTEAM_COLOR` | `--color` |
 | `CLAUDE_ANYTEAM_LOG` | `--log` |

--- a/src/claude_anyteam/app_server.py
+++ b/src/claude_anyteam/app_server.py
@@ -2,7 +2,16 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable
+from contextlib import contextmanager
+import os
+from pathlib import Path
+import random
+import time
+from typing import Any, Callable, Iterator, Mapping
+
+from filelock import Timeout
+
+from claude_teams._filelock import file_lock
 
 from . import logger
 from .jsonrpc_stdio import JsonRpcStdioClient, JsonRpcStdioError
@@ -10,6 +19,130 @@ from .jsonrpc_stdio import JsonRpcStdioClient, JsonRpcStdioError
 
 class AppServerError(JsonRpcStdioError):
     """Raised on Codex App Server protocol/transport errors."""
+
+
+APP_SERVER_START_GATE_ENV = "CLAUDE_ANYTEAM_APP_SERVER_START_GATE"
+APP_SERVER_START_GATE_LOCK_PATH_ENV = "CLAUDE_ANYTEAM_APP_SERVER_START_GATE_LOCK_PATH"
+APP_SERVER_START_GATE_LOCK_TIMEOUT_ENV = (
+    "CLAUDE_ANYTEAM_APP_SERVER_START_GATE_LOCK_TIMEOUT_S"
+)
+APP_SERVER_START_GATE_JITTER_ENV = "CLAUDE_ANYTEAM_APP_SERVER_START_GATE_JITTER_S"
+APP_SERVER_START_GATE_COOLDOWN_ENV = "CLAUDE_ANYTEAM_APP_SERVER_START_GATE_COOLDOWN_S"
+
+_DEFAULT_START_GATE_LOCK_TIMEOUT_S = 5.0
+_DEFAULT_START_GATE_JITTER_S = 0.25
+_DEFAULT_START_GATE_COOLDOWN_S = 0.25
+_FALSEY = {"0", "false", "no", "off", "disabled"}
+
+
+def _float_env(env: Mapping[str, str], name: str, default: float) -> float:
+    raw = env.get(name)
+    if raw is None or raw == "":
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        return default
+    return max(0.0, value)
+
+
+def _start_gate_enabled(env: Mapping[str, str]) -> bool:
+    raw = env.get(APP_SERVER_START_GATE_ENV)
+    if raw is None or raw == "":
+        return True
+    return raw.strip().lower() not in _FALSEY
+
+
+def _start_gate_lock_path(env: Mapping[str, str]) -> Path:
+    raw = env.get(APP_SERVER_START_GATE_LOCK_PATH_ENV)
+    if raw:
+        return Path(raw).expanduser()
+    return Path.home() / ".claude" / "claude-anyteam" / "codex-app-server-start.lock"
+
+
+@contextmanager
+def app_server_start_gate(
+    *,
+    env: Mapping[str, str] | None = None,
+    rng: random.Random | None = None,
+) -> Iterator[dict[str, Any]]:
+    """Briefly serialize Codex App Server cold starts across wrappers (#40).
+
+    The original #40 incident was ultimately dominated by Codex sqlite WAL
+    bloat, but concurrent cold starts still compete on Codex-owned global
+    resources (sqlite state, auth/cache startup, helper binaries). This gate
+    preserves the native Codex harness while adding a tiny cross-process
+    critical section around child-process launch: a randomized pre-lock jitter,
+    a bounded file lock, and a short post-launch cool-down. If the lock cannot
+    be acquired quickly, startup proceeds rather than turning the mitigation
+    into a new hang.
+    """
+
+    env_map = env if env is not None else os.environ
+    if not _start_gate_enabled(env_map):
+        yield {"enabled": False, "locked": False}
+        return
+
+    rand = rng if rng is not None else random
+    jitter_s = _float_env(
+        env_map,
+        APP_SERVER_START_GATE_JITTER_ENV,
+        _DEFAULT_START_GATE_JITTER_S,
+    )
+    actual_jitter_s = rand.uniform(0.0, jitter_s) if jitter_s > 0 else 0.0
+    if actual_jitter_s > 0:
+        time.sleep(actual_jitter_s)
+
+    lock_timeout_s = _float_env(
+        env_map,
+        APP_SERVER_START_GATE_LOCK_TIMEOUT_ENV,
+        _DEFAULT_START_GATE_LOCK_TIMEOUT_S,
+    )
+    cooldown_s = _float_env(
+        env_map,
+        APP_SERVER_START_GATE_COOLDOWN_ENV,
+        _DEFAULT_START_GATE_COOLDOWN_S,
+    )
+    lock_path = _start_gate_lock_path(env_map)
+    try:
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path.touch(exist_ok=True)
+    except OSError as exc:
+        logger.warn("app_server.start_gate_prepare_failed", path=str(lock_path), error=str(exc))
+        yield {"enabled": True, "locked": False, "error": str(exc)}
+        return
+
+    wait_started = time.monotonic()
+    try:
+        with file_lock(lock_path, timeout=lock_timeout_s):
+            wait_ms = int((time.monotonic() - wait_started) * 1000)
+            state = {
+                "enabled": True,
+                "locked": True,
+                "lock_path": str(lock_path),
+                "wait_ms": wait_ms,
+                "jitter_ms": int(actual_jitter_s * 1000),
+                "cooldown_ms": int(cooldown_s * 1000),
+            }
+            logger.info("app_server.start_gate_acquired", **state)
+            try:
+                yield state
+            finally:
+                if cooldown_s > 0:
+                    time.sleep(cooldown_s)
+    except Timeout:
+        logger.warn(
+            "app_server.start_gate_timeout",
+            path=str(lock_path),
+            timeout_s=lock_timeout_s,
+            jitter_ms=int(actual_jitter_s * 1000),
+        )
+        yield {
+            "enabled": True,
+            "locked": False,
+            "lock_path": str(lock_path),
+            "timeout_s": lock_timeout_s,
+        }
 
 
 class AppServerClient(JsonRpcStdioClient):
@@ -47,11 +180,12 @@ class AppServerClient(JsonRpcStdioClient):
         self.last_thread_result: dict[str, Any] | None = None
 
     def start(self) -> None:
-        """Start the child process after any wrapper-side preflight hook."""
+        """Start Codex App Server behind the #40 cold-start gate after any wrapper-side preflight hook."""
 
         if self._pre_start_hook is not None:
             self._pre_start_hook()
-        super().start()
+        with app_server_start_gate(env=self._env):
+            super().start()
 
     # ---- transport health / restart ---------------------------------------
 

--- a/src/claude_anyteam/codex.py
+++ b/src/claude_anyteam/codex.py
@@ -764,6 +764,12 @@ def run(
 
 _DEFAULT_INITIALIZE_TIMEOUT_S = 90.0
 _DEFAULT_INITIALIZE_PROGRESS_INTERVAL_S = 30.0
+_DEFAULT_INITIALIZE_RETRIES = 1
+_DEFAULT_INITIALIZE_RETRY_BACKOFF_S = 2.0
+APP_SERVER_INITIALIZE_RETRIES_ENV = "CLAUDE_ANYTEAM_APP_SERVER_INITIALIZE_RETRIES"
+APP_SERVER_INITIALIZE_RETRY_BACKOFF_ENV = (
+    "CLAUDE_ANYTEAM_APP_SERVER_INITIALIZE_RETRY_BACKOFF_S"
+)
 
 
 def _read_float_env(name: str, default: float, *, allow_zero: bool = False) -> float:
@@ -777,6 +783,21 @@ def _read_float_env(name: str, default: float, *, allow_zero: bool = False) -> f
     if allow_zero:
         return max(0.0, value)
     return max(0.001, value)
+
+
+def _read_int_env(name: str, default: int, *, min_value: int = 0, max_value: int = 5) -> int:
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    return min(max_value, max(min_value, value))
+
+
+def _is_initialize_timeout_error(exc: BaseException) -> bool:
+    return "did not respond to initialize" in str(exc).lower()
 
 
 def _read_proc_cpu_pct(pid: int) -> float | None:
@@ -1783,13 +1804,65 @@ def app_server_invoke(
     if model is not None:
         thread_kwargs["model"] = model
 
-    try:
-        client.start()
-        _initialize_with_progress_events(
-            client,
-            emit_visibility=_emit_visibility_event,
-            prompt_byte_size=len(task_prompt.encode("utf-8")),
+    def _start_and_initialize_with_retry() -> None:
+        max_retries = _read_int_env(
+            APP_SERVER_INITIALIZE_RETRIES_ENV,
+            _DEFAULT_INITIALIZE_RETRIES,
+            min_value=0,
+            max_value=3,
         )
+        backoff_s = _read_float_env(
+            APP_SERVER_INITIALIZE_RETRY_BACKOFF_ENV,
+            _DEFAULT_INITIALIZE_RETRY_BACKOFF_S,
+            allow_zero=True,
+        )
+        attempt = 0
+        while True:
+            try:
+                client.start()
+                _initialize_with_progress_events(
+                    client,
+                    emit_visibility=_emit_visibility_event,
+                    prompt_byte_size=len(task_prompt.encode("utf-8")),
+                )
+                return
+            except AppServerError as exc:
+                if not _is_initialize_timeout_error(exc) or attempt >= max_retries:
+                    raise
+                attempt += 1
+                _emit_visibility_event(
+                    kind="turn_warning",
+                    severity="warn",
+                    summary=(
+                        "Codex App Server initialize timed out; "
+                        f"retrying cold start ({attempt}/{max_retries})"
+                    ),
+                    visibility={
+                        "mailbox": False,
+                        "task_state": True,
+                        "event_log": True,
+                        "stderr": True,
+                    },
+                    payload={
+                        "surface": "app_server_initialize_retry",
+                        "attempt": attempt,
+                        "max_retries": max_retries,
+                        "backoff_s": backoff_s,
+                        "raw_backend_error": str(exc)[:600],
+                    },
+                )
+                try:
+                    client.close()
+                except Exception as close_exc:
+                    logger.debug(
+                        "app_server.initialize_retry_close_failed",
+                        error=str(close_exc),
+                    )
+                if backoff_s > 0:
+                    time.sleep(backoff_s)
+
+    try:
+        _start_and_initialize_with_retry()
 
         thread_id = _start_or_fork_thread(
             client,

--- a/tests/test_app_server_phase2.py
+++ b/tests/test_app_server_phase2.py
@@ -1,0 +1,125 @@
+"""Regression tests for #40 Phase 2 Codex App Server cold-start mitigation."""
+
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+from claude_anyteam import app_server as app_server_mod
+from claude_anyteam import codex as codex_mod
+from claude_anyteam.app_server import (
+    APP_SERVER_START_GATE_COOLDOWN_ENV,
+    APP_SERVER_START_GATE_JITTER_ENV,
+    APP_SERVER_START_GATE_LOCK_PATH_ENV,
+    app_server_start_gate,
+)
+
+
+def test_app_server_start_gate_serializes_threads(tmp_path: Path) -> None:
+    lock_path = tmp_path / "codex-app-server-start.lock"
+    env = {
+        APP_SERVER_START_GATE_LOCK_PATH_ENV: str(lock_path),
+        APP_SERVER_START_GATE_JITTER_ENV: "0",
+        APP_SERVER_START_GATE_COOLDOWN_ENV: "0",
+    }
+    active = 0
+    max_active = 0
+    guard = threading.Lock()
+    barrier = threading.Barrier(3)
+
+    def worker() -> None:
+        nonlocal active, max_active
+        barrier.wait()
+        with app_server_start_gate(env=env):
+            with guard:
+                active += 1
+                max_active = max(max_active, active)
+            time.sleep(0.05)
+            with guard:
+                active -= 1
+
+    threads = [threading.Thread(target=worker) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    barrier.wait()
+    for thread in threads:
+        thread.join(timeout=5)
+
+    assert max_active == 1
+
+
+def test_app_server_initialize_timeout_retries_once(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv(codex_mod.APP_SERVER_INITIALIZE_RETRY_BACKOFF_ENV, "0")
+    monkeypatch.setenv(codex_mod.APP_SERVER_INITIALIZE_RETRIES_ENV, "1")
+
+    captured = []
+
+    class _Queue:
+        def __init__(self) -> None:
+            self._items = [
+                {"method": "turn/completed", "params": {"turn": {"status": "ok"}}}
+            ]
+
+        def get(self, timeout=None):
+            if self._items:
+                return self._items.pop(0)
+            raise RuntimeError("empty (test)")
+
+    class _RetryClient:
+        starts = 0
+        closes = 0
+        initializes = 0
+
+        def __init__(self, *args, **kwargs) -> None:
+            self.notifications = _Queue()
+
+        def start(self) -> None:
+            type(self).starts += 1
+
+        def initialize(self, **_kwargs):
+            type(self).initializes += 1
+            if type(self).initializes == 1:
+                raise app_server_mod.AppServerError(
+                    "JSON-RPC stdio process did not respond to initialize within 0.01s"
+                )
+            return {}
+
+        def thread_start(self, **kwargs):
+            return "thread-id"
+
+        def turn_start(self, **kwargs):
+            return "turn-id"
+
+        def drain_notifications(self):
+            return []
+
+        def turn_interrupt(self, **kwargs):
+            pass
+
+        def close(self, **kwargs):
+            type(self).closes += 1
+
+    with patch.object(app_server_mod, "AppServerClient", _RetryClient):
+        result = codex_mod.app_server_invoke(
+            task_prompt="noop",
+            cwd=tmp_path,
+            schema=None,
+            settings_team="team",
+            settings_agent="codex-a",
+            event_sink=captured.append,
+        )
+
+    assert result.exit_code == 0
+    assert _RetryClient.starts == 2
+    assert _RetryClient.initializes == 2
+    assert _RetryClient.closes >= 2  # retry cleanup + final close
+    retry_events = [
+        event
+        for event in captured
+        if event.payload.get("surface") == "app_server_initialize_retry"
+    ]
+    assert len(retry_events) == 1
+    assert retry_events[0].kind == "turn_warning"
+    assert retry_events[0].payload["attempt"] == 1


### PR DESCRIPTION
## Summary

- add a bounded cross-process Codex App Server cold-start gate: randomized pre-start jitter, file-lock serialization, and short post-start cooldown
- retry JSON-RPC `initialize` timeouts once with typed `turn_warning(surface=app_server_initialize_retry)` before surfacing the existing failure path
- document the new knobs and cover the gate + retry paths with unit tests

## Proof of repro / baseline

The original #40 failing sequence from the issue was:

```text
codex_app_server_mcp_config_prepared
... no codex_app_server_session_start ...
turn_failed: JSON-RPC stdio process did not respond to initialize within 600.0s
```

On this host after isolating sqlite state (so #43 WAL bloat is not part of the measurement), I ran a wrapper-level equivalent of a two-`codex-*` Agent batch: two concurrent `AppServerClient` cold starts + `initialize`, N=5 pairs, with a temp `CODEX_SQLITE_HOME` to avoid touching the user's real `~/.codex` logs.

Pre-fix baseline did not reproduce the full hang on this now-clean host, but established timing:

```text
run 1: client1 ok=True elapsed=0.44s | client2 ok=True elapsed=0.37s
run 2: client1 ok=True elapsed=0.42s | client2 ok=True elapsed=0.48s
run 3: client1 ok=True elapsed=0.42s | client2 ok=True elapsed=0.47s
run 4: client1 ok=True elapsed=0.97s | client2 ok=True elapsed=1.07s
run 5: client1 ok=True elapsed=1.19s | client2 ok=True elapsed=1.17s
```

A unit repro simulates the actionable Phase 2 failure mode: first initialize raises `JSON-RPC stdio process did not respond to initialize...`; before this PR, `app_server_invoke` returned the failure immediately and loop-side code marked the task/prose turn failed.

## Proof of fix

Post-fix concurrent cold-start timings with the gate enabled, same N=5 pairs and temp sqlite home:

```text
run 1: client1 ok=True elapsed=0.68s | client2 ok=True elapsed=0.49s
run 2: client1 ok=True elapsed=0.62s | client2 ok=True elapsed=0.44s
run 3: client1 ok=True elapsed=0.55s | client2 ok=True elapsed=0.73s
run 4: client1 ok=True elapsed=0.78s | client2 ok=True elapsed=0.65s
run 5: client1 ok=True elapsed=0.68s | client2 ok=True elapsed=0.86s
max_elapsed=0.86s p95_approx=0.78s
```

The simulated initialize-timeout repro now retries once and succeeds. Event sequence includes the new typed retry warning before the successful turn:

```text
turn_warning surface=app_server_initialize_retry attempt=1 max_retries=1
app_server_initialize_completed
turn_started
turn_completed
```

## Tests

```text
uv run pytest -q tests/test_app_server_phase2.py tests/test_app_server_initialize_visibility.py tests/test_app_server_client.py tests/test_app_server_process_group.py tests/test_task_blocked_initialize_timeout.py tests/test_prose_bound_initialize_timeout.py
36 passed in 9.57s

uv run pytest -q
1136 passed, 11 skipped, 2 deselected, 1 warning in 163.88s (0:02:43)
```

Fixes #40
