### PR TITLE
feat(#49): emit unrecovered wrapper-tool failure signal

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,6 +19,10 @@ claude-anyteam \
   --effort <level>          # low | medium | high | xhigh (default: Codex's default)
   --plan-mode               # opt into plan approval mode
   --no-app-server           # opt out of App Server mode (use fresh-exec instead)
+  --turn-timeout-s <sec>    # Codex App Server turn cap (default: 900; range [60, 3600])
+  --non-progress-warn-s <sec>             # soft progress watchdog (default: 300; range [60, 900])
+  --non-progress-interrupt-s <sec>        # opt-in hard progress interrupt (default: unset)
+  --wrapper-tool-failure-window-s <sec>   # #49 unrecovered wrapper-tool signal window (default: 90; range [60, 300])
   --poll-s <float>          # inbox poll interval in seconds (default: 1.5)
   --color <name>            # display color in peer DMs (default: cyan)
   --log <level>             # debug | info | warn | error (default: info)
@@ -80,6 +84,10 @@ Every flag has an equivalent env var:
 | `CLAUDE_ANYTEAM_APP_SERVER_START_GATE_COOLDOWN_S` | short post-start serialization window before another Codex App Server spawn proceeds (default `0.25`) |
 | `CLAUDE_ANYTEAM_APP_SERVER_INITIALIZE_RETRIES` | retry count for Codex App Server initialize timeouts before surfacing failure (default `1`) |
 | `CLAUDE_ANYTEAM_APP_SERVER_INITIALIZE_RETRY_BACKOFF_S` | backoff before the initialize retry (default `2.0`) |
+| `CLAUDE_ANYTEAM_TURN_TIMEOUT_S` | `--turn-timeout-s` |
+| `CLAUDE_ANYTEAM_NON_PROGRESS_WARN_S` | `--non-progress-warn-s` |
+| `CLAUDE_ANYTEAM_NON_PROGRESS_INTERRUPT_S` | `--non-progress-interrupt-s` |
+| `CLAUDE_ANYTEAM_WRAPPER_TOOL_FAILURE_WINDOW_S` | `--wrapper-tool-failure-window-s` |
 | `CLAUDE_ANYTEAM_POLL_S` | `--poll-s` |
 | `CLAUDE_ANYTEAM_COLOR` | `--color` |
 | `CLAUDE_ANYTEAM_LOG` | `--log` |
@@ -107,27 +115,29 @@ Claude Code's Agent Teams UI only passes name, team, and plan-mode to the spawn 
 
 ```bash
 claude-anyteam team-agent codex-alice --team build --model gpt-5.5 --effort xhigh
+claude-anyteam team-agent codex-alice --team build --wrapper-tool-failure-window-s 120
 claude-anyteam team-agent gemini-bob  --team build --model gemini-3-pro-preview --effort high
 claude-anyteam team-agent codex-alice --team build --remove                       # delete the file
 ```
 
-The CLI writes atomically, validates the agent/team names against path-traversal, drops unknown keys (only `model` / `effort` are honored), and is idempotent — re-running with the same args is a no-op. The on-disk shape is JSON that the shim reads at spawn time:
+The CLI writes atomically, validates the agent/team names against path-traversal, drops unknown keys (only `model`, `effort`, and the allowlisted Codex App Server timing knobs are honored), and is idempotent — re-running with the same args is a no-op. The on-disk shape is JSON that the shim reads at spawn time:
 
 ```json
 {
   "model": "kimi-code/kimi-for-coding",
-  "effort": "xhigh"
+  "effort": "xhigh",
+  "wrapper_tool_failure_window_s": 120
 }
 ```
 
-When the shim dispatches a `codex-*`, `gemini-*`, or `kimi-*` teammate, it requires this file to exist, reads it, and appends `--model` / `--effort` to the adapter invocation when those keys are present. For Codex, the effect is identical to typing those flags on the command line — both App Server and fresh-exec modes pick them up through the shared `Settings` object. For Gemini, `--effort` maps through adapter-owned model aliases when supported by the selected Gemini model family. For Kimi, `--model` is passed as `--model <slug>` and effort controls thinking on/off as above.
+When the shim dispatches a `codex-*`, `gemini-*`, or `kimi-*` teammate, it requires this file to exist, reads it, and appends `--model` / `--effort` to the adapter invocation when those keys are present. For Codex, the effect is identical to typing those flags on the command line — both App Server and fresh-exec modes pick them up through the shared `Settings` object. Codex-only timing keys (`turn_timeout_s`, `non_progress_warn_s`, `non_progress_interrupt_s`, `wrapper_tool_failure_window_s`) are forwarded only to Codex spawns. For Gemini, `--effort` maps through adapter-owned model aliases when supported by the selected Gemini model family. For Kimi, `--model` is passed as `--model <slug>` and effort controls thinking on/off as above.
 
 Behavior:
 
 - Missing file for a routed prefix (`codex-*`, `gemini-*`, `kimi-*`, or a custom external route) — soft-refuse with `spawn_shim.bare_prefix_refused`, including the expected config path, a `claude-anyteam team-agent ...` command, and the escape hatch below.
 - `CLAUDE_ANYTEAM_ALLOW_BARE_PREFIX=1` — advanced escape hatch: allow a routed prefix to start with adapter defaults when no per-teammate file exists. Use only when intentionally bypassing `team-agent`; leaving it unset is what prevents silent native-Claude-looking fallbacks.
 - Malformed JSON or unreadable file — logs `spawn_shim.agent_config_error` to stderr and continues; teammate still starts.
-- Unknown keys — ignored. Only `model` and `effort` are forwarded today; more keys may be added later.
+- Unknown keys — ignored. Only `model`, `effort`, `turn_timeout_s`, `non_progress_warn_s`, `non_progress_interrupt_s`, and `wrapper_tool_failure_window_s` are forwarded today; more keys may be added later.
 - Native (`claude-*`) teammates — the file is not consulted; native dispatch is always pass-through.
 
 Precedence (highest wins): per-agent config file → env vars (`CLAUDE_ANYTEAM_MODEL`, `CLAUDE_ANYTEAM_EFFORT` for Codex/Kimi, `CLAUDE_ANYTEAM_GEMINI_EFFORT` / `CLAUDE_ANYTEAM_GEMINI_TRUST` for Gemini, `CLAUDE_ANYTEAM_KIMI_THINKING` for Kimi thinking override) → adapter defaults → backend CLI defaults.
@@ -150,7 +160,7 @@ Three subcommands of `claude-anyteam` cover the routine team-management writes t
 
 | Command | Purpose |
 |---|---|
-| `claude-anyteam team-agent <name> --team <team> [--model X] [--effort Y]` | Write `~/.claude/teams/<team>/agents/<name>.json`. Whitelisted keys: `model`, `effort`. Use `--remove` to delete. `--print-path` emits the file path on stdout. |
+| `claude-anyteam team-agent <name> --team <team> [--model X] [--effort Y] [--wrapper-tool-failure-window-s N]` | Write `~/.claude/teams/<team>/agents/<name>.json`. Whitelisted keys: `model`, `effort`, and Codex App Server timing knobs (`turn_timeout_s`, `non_progress_warn_s`, `non_progress_interrupt_s`, `wrapper_tool_failure_window_s`). Use `--remove` to delete. `--print-path` emits the file path on stdout. |
 | `claude-anyteam team-patch <name> --team <team>` <br> `claude-anyteam team-patch --team <team> --all-external` | Set `agentType="claude-anyteam"` on a routed-adapter member in `~/.claude/teams/<team>/config.json`. The host `Agent(...)` tool spawns external-LLM teammates with `agentType="general-purpose"` which the wrapper MCP rejects; this command is the post-spawn fixup. `--all-external` patches every `codex-*`, `gemini-*`, or `kimi-*` member at once. |
 | `claude-anyteam team-roster --team <team>` <br> `claude-anyteam team-roster --team <team> --json` | Print a one-line-per-member roster summary (or a JSON array) so a coordinating LLM can introspect the team without parsing config.json. |
 

--- a/src/claude_anyteam/cli.py
+++ b/src/claude_anyteam/cli.py
@@ -267,6 +267,18 @@ def _build_run_parser() -> argparse.ArgumentParser:
             "`warn_active` field tells which path fired."
         ),
     )
+    p.add_argument(
+        "--wrapper-tool-failure-window-s",
+        type=float,
+        help=(
+            "Codex App Server wrapper-tool recovery discriminator window in "
+            "seconds. Range [60, 300], default 90. Overrides "
+            "CLAUDE_ANYTEAM_WRAPPER_TOOL_FAILURE_WINDOW_S. If a wrapper MCP "
+            "tool fails and no turn_progress/tool_event/artifact_event/"
+            "agentMessage delta appears within this window, the adapter emits "
+            "wrapper_tool_failure_unrecovered as signal only."
+        ),
+    )
     return p
 
 
@@ -1126,6 +1138,8 @@ def main(argv: list[str] | None = None) -> int:
         overrides["non_progress_warn_s"] = args.non_progress_warn_s
     if args.non_progress_interrupt_s is not None:
         overrides["non_progress_interrupt_s"] = args.non_progress_interrupt_s
+    if args.wrapper_tool_failure_window_s is not None:
+        overrides["wrapper_tool_failure_window_s"] = args.wrapper_tool_failure_window_s
 
     try:
         settings = from_env(overrides=overrides)
@@ -1145,6 +1159,7 @@ def main(argv: list[str] | None = None) -> int:
         turn_timeout_s=settings.turn_timeout_s,
         non_progress_warn_s=settings.non_progress_warn_s,
         non_progress_interrupt_s=settings.non_progress_interrupt_s,
+        wrapper_tool_failure_window_s=settings.wrapper_tool_failure_window_s,
     )
     return run(settings)
 

--- a/src/claude_anyteam/codex.py
+++ b/src/claude_anyteam/codex.py
@@ -109,31 +109,21 @@ _TOOL_CALL_TYPE_SUBSTRINGS = (
     "imageview",           # Codex App Server image view
 )
 
-# Tool names our wrapper MCP server advertises. If any event payload
-# references one of these by name, it's a tool call — regardless of how
-# Codex spells the event type.
-_WRAPPER_TOOL_NAMES = frozenset({
-    "send_message",
-    "task_update",
-    "checkpoint_commit",
-    "task_create",
-    "read_inbox",
-    "task_list",
-    "read_config",
-})
-
 # Keep this diagnostic snapshot in sync with wrapper_server.EXPOSED_TOOLS.
 # Duplicated here intentionally so codex.py can log session-start state
 # without importing FastMCP/wrapper_server on the hot path.
 _WRAPPER_EXPECTED_TOOL_NAMES = (
     "send_message",
     "task_update",
+    "checkpoint_commit",
     "task_create",
     "task_batch_summary",
     "read_inbox",
     "task_list",
     "read_config",
     "mcp_anyteam_capability_manifest",
+    "mcp_anyteam_list_skills",
+    "mcp_anyteam_invoke_skill",
     "mcp_anyteam_shell",
     "mcp_anyteam_read_file",
     "mcp_anyteam_write_file",
@@ -143,6 +133,32 @@ _WRAPPER_EXPECTED_TOOL_NAMES = (
     "mcp_anyteam_grep",
     "mcp_anyteam_web_fetch",
 )
+
+# Tool names our wrapper MCP server advertises. If any event payload
+# references one of these by name, it's a tool call — regardless of how
+# Codex spells the event type. Keep this as the set form of
+# _WRAPPER_EXPECTED_TOOL_NAMES so #49 shadow-tool failures (for example
+# mcp_anyteam_read_file ENOENT) participate in the same recovery logic as
+# core team tools.
+_WRAPPER_TOOL_NAMES = frozenset(_WRAPPER_EXPECTED_TOOL_NAMES)
+
+_WRAPPER_TOOL_RECOVERY_EVENT_KINDS = frozenset(
+    {"turn_progress", "tool_event", "artifact_event"}
+)
+
+
+@dataclass
+class _PendingWrapperToolFailure:
+    failed_event_id: str
+    failed_event_seq: int
+    failed_at_monotonic: float
+    tool_name: str
+    error_class: str
+    error_detail: str | None
+    turn_id: str | None
+    recovered_at_monotonic: float | None = None
+    recovery_event_id: str | None = None
+    emitted: bool = False
 
 
 
@@ -159,6 +175,61 @@ def _bounded_preview(value: Any, *, limit: int = 1000) -> Any:
             for k, v in list(value.items())[:50]
         }
     return _bounded_preview(repr(value), limit=limit)
+
+
+def _wrapper_tool_error_detail(payload: dict[str, Any]) -> str | None:
+    """Best-effort bounded detail string for a failed wrapper-tool event."""
+
+    for key in (
+        "error",
+        "error_detail",
+        "stderr_preview",
+        "stdout_preview",
+        "raw_event_preview",
+    ):
+        value = payload.get(key)
+        if value not in (None, ""):
+            return str(_bounded_preview(value, limit=600))
+    return None
+
+
+def _wrapper_tool_error_class(payload: dict[str, Any]) -> str:
+    """Return a stable-ish mid-turn wrapper-tool error discriminator.
+
+    This deliberately does not feed diagnostics.ERROR_CLASSES: #49's
+    unrecovered envelope is an in-flight visibility signal, not a terminal
+    turn failure. The class here is forensic payload only.
+    """
+
+    detail = " ".join(
+        str(value)
+        for value in (
+            payload.get("status"),
+            payload.get("error"),
+            payload.get("stderr_preview"),
+            payload.get("raw_event_preview"),
+        )
+        if value not in (None, "")
+    ).lower()
+    if any(fragment in detail for fragment in ("errno 2", "enoent", "no such file")):
+        return "enoent"
+    if any(fragment in detail for fragment in ("validation", "schema")):
+        return "schema_validation"
+    if "timeout" in detail or "timed out" in detail:
+        return "timeout"
+    if "not found" in detail:
+        return "not_found"
+    status = payload.get("status")
+    if isinstance(status, str) and status:
+        return status
+    return "wrapper_tool_error"
+
+
+def _is_failed_wrapper_tool_event(event: VisibilityEvent | None) -> bool:
+    if event is None or event.kind != "tool_event" or event.severity != "error":
+        return False
+    tool_name = event.payload.get("tool_name")
+    return isinstance(tool_name, str) and tool_name in _WRAPPER_TOOL_NAMES
 
 
 def _toolish_fields(value: Any, *, depth: int = 0, path: str = "") -> dict[str, Any]:
@@ -1521,6 +1592,7 @@ def app_server_invoke(
     overall_timeout_s: float = 1800.0,
     non_progress_warn_s: float | None = None,
     non_progress_interrupt_s: float | None = None,
+    wrapper_tool_failure_window_s: float = 90.0,
     steer_queue: "_SteerQueue | None" = None,
     mid_turn_hook: "Any | None" = None,
     resume_thread_id: str | None = None,
@@ -1573,6 +1645,7 @@ def app_server_invoke(
     current_turn_id: str | None = None
     turn_started_at: float | None = None
     visibility_seq = 0
+    pending_wrapper_tool_failures: list[_PendingWrapperToolFailure] = []
 
     def _emit_visibility_event(
         *,
@@ -1607,6 +1680,15 @@ def app_server_invoke(
                 "payload": payload,
             }
         )
+        if event.kind in _WRAPPER_TOOL_RECOVERY_EVENT_KINDS:
+            recovered_at = time.monotonic()
+            for pending in pending_wrapper_tool_failures:
+                if (
+                    pending.recovered_at_monotonic is None
+                    and event.seq > pending.failed_event_seq
+                ):
+                    pending.recovered_at_monotonic = recovered_at
+                    pending.recovery_event_id = event.event_id
         if event.visibility.stderr:
             log_payload = {
                 "kind": event.kind,
@@ -1736,11 +1818,29 @@ def app_server_invoke(
                     tool=_tool_name_from_event(fake_ev),
                     event={"item": item},
                 )
-            _visibility_for_app_server_item(
+            visibility_event = _visibility_for_app_server_item(
                 method=method,
                 item=item,
                 make_event=_emit_visibility_event,
             )
+            if _is_failed_wrapper_tool_event(visibility_event):
+                if visibility_event is None:
+                    return
+                pending_wrapper_tool_failures.append(
+                    _PendingWrapperToolFailure(
+                        failed_event_id=visibility_event.event_id,
+                        failed_event_seq=visibility_event.seq,
+                        failed_at_monotonic=time.monotonic(),
+                        tool_name=str(visibility_event.payload["tool_name"]),
+                        error_class=_wrapper_tool_error_class(
+                            visibility_event.payload
+                        ),
+                        error_detail=_wrapper_tool_error_detail(
+                            visibility_event.payload
+                        ),
+                        turn_id=visibility_event.turn_id,
+                    )
+                )
 
     # MCP config for the wrapper — same shape as the exec path, injected via
     # Codex's config override mechanism on thread start. App Server accepts
@@ -1909,6 +2009,7 @@ def app_server_invoke(
                 "timeout_s": overall_timeout_s,
                 "non_progress_soft_s": non_progress_warn_s,
                 "non_progress_interrupt_s": non_progress_interrupt_s,
+                "wrapper_tool_failure_window_s": wrapper_tool_failure_window_s,
                 "cwd": str(cwd),
                 "model": model,
                 "effort": effort,
@@ -1939,6 +2040,56 @@ def app_server_invoke(
         non_progress_interrupted = False
         transport_reconnect_attempts = 0
         done = False
+
+        def _emit_unrecovered_wrapper_tool_failures(now: float) -> None:
+            """Emit #49's Mode-B signal for wrapper-tool failures.
+
+            Mode A recovery is marked in `_emit_visibility_event` when any
+            later turn_progress/tool_event/artifact_event arrives (including
+            agentMessage deltas, which normalize to turn_progress). This
+            checker only fires after W when no such recovery event appeared.
+            It is signal-only: no steer, interrupt, or kill.
+            """
+
+            for pending in pending_wrapper_tool_failures:
+                if (
+                    pending.emitted
+                    or pending.recovered_at_monotonic is not None
+                    or (now - pending.failed_at_monotonic)
+                    < wrapper_tool_failure_window_s
+                ):
+                    continue
+                pending.emitted = True
+                silence_window_ms = int(wrapper_tool_failure_window_s * 1000)
+                payload: dict[str, Any] = {
+                    "tool_name": pending.tool_name,
+                    "error_class": pending.error_class,
+                    "error_detail": pending.error_detail,
+                    "turn_id": pending.turn_id,
+                    "failed_event_id": pending.failed_event_id,
+                    "failed_event_seq": pending.failed_event_seq,
+                    "last_progress_elapsed_s": int(
+                        last_progress_at - turn_started_at
+                    ),
+                    "silence_window_ms": silence_window_ms,
+                    "recovery_hint_dispatched": False,
+                }
+                payload = {k: v for k, v in payload.items() if v is not None}
+                _emit_visibility_event(
+                    kind="wrapper_tool_failure_unrecovered",
+                    severity="warn",
+                    summary=(
+                        f"wrapper tool {pending.tool_name} failed; no recovery "
+                        f"activity in {int(wrapper_tool_failure_window_s)}s"
+                    )[:200],
+                    visibility={
+                        "mailbox": True,
+                        "task_state": True,
+                        "event_log": True,
+                        "stderr": True,
+                    },
+                    payload=payload,
+                )
 
         def _resume_kwargs() -> dict[str, Any]:
             """Map thread/start kwargs to the subset accepted by thread/resume."""
@@ -2194,6 +2345,8 @@ def app_server_invoke(
             )
 
         while not done and time.monotonic() < deadline:
+            _emit_unrecovered_wrapper_tool_failures(time.monotonic())
+
             # 1. Deliver any pending steers. Non-blocking pop.
             if steer_queue is not None:
                 while True:
@@ -2261,6 +2414,7 @@ def app_server_invoke(
                 # ordering semantics.
                 now = time.monotonic()
                 warn_active = non_progress_warn_s is not None
+                _emit_unrecovered_wrapper_tool_failures(now)
                 if (
                     warn_active
                     and not non_progress_warned

--- a/src/claude_anyteam/codex.py
+++ b/src/claude_anyteam/codex.py
@@ -2345,8 +2345,6 @@ def app_server_invoke(
             )
 
         while not done and time.monotonic() < deadline:
-            _emit_unrecovered_wrapper_tool_failures(time.monotonic())
-
             # 1. Deliver any pending steers. Non-blocking pop.
             if steer_queue is not None:
                 while True:

--- a/src/claude_anyteam/config.py
+++ b/src/claude_anyteam/config.py
@@ -36,6 +36,7 @@ from .env import (
     PLAN_MODE_ENV,
     TEAM_ENV,
     TURN_TIMEOUT_ENV,
+    WRAPPER_TOOL_FAILURE_WINDOW_ENV,
     env_first,
 )
 
@@ -97,6 +98,12 @@ class Settings:
     # turn_timeout_s cap. When set, R20 only uses it after the soft watchdog
     # has fired and no later checkpoint is observed.
     non_progress_interrupt_s: float | None = None
+    # #49 / RFC §5.1: after a wrapper MCP tool error, emit
+    # wrapper_tool_failure_unrecovered only if no turn_progress/tool_event/
+    # artifact_event/agentMessage_delta appears within this window. Signal
+    # only: the adapter does not steer, interrupt, or kill because of it.
+    # Range [60, 300].
+    wrapper_tool_failure_window_s: float = 90.0
 
 
 def from_env(overrides: dict[str, object] | None = None) -> Settings:
@@ -227,6 +234,28 @@ def from_env(overrides: dict[str, object] | None = None) -> Settings:
                 f"got {non_progress_interrupt_s}"
             )
 
+    wrapper_tool_failure_window_raw = _pick(
+        overrides,
+        "wrapper_tool_failure_window_s",
+        env_first(
+            os.environ,
+            WRAPPER_TOOL_FAILURE_WINDOW_ENV,
+            default="90",
+        ),
+    )
+    try:
+        wrapper_tool_failure_window_s = float(wrapper_tool_failure_window_raw)
+    except (TypeError, ValueError) as e:
+        raise ValueError(
+            "wrapper_tool_failure_window_s must be numeric, "
+            f"got {wrapper_tool_failure_window_raw!r}"
+        ) from e
+    if not (60.0 <= wrapper_tool_failure_window_s <= 300.0):
+        raise ValueError(
+            "wrapper_tool_failure_window_s must be in [60, 300] seconds, "
+            f"got {wrapper_tool_failure_window_s}"
+        )
+
     return Settings(
         team_name=str(team_name),
         agent_name=str(agent_name),
@@ -241,6 +270,7 @@ def from_env(overrides: dict[str, object] | None = None) -> Settings:
         turn_timeout_s=turn_timeout_s,
         non_progress_warn_s=non_progress_warn_s,
         non_progress_interrupt_s=non_progress_interrupt_s,
+        wrapper_tool_failure_window_s=wrapper_tool_failure_window_s,
     )
 
 

--- a/src/claude_anyteam/env.py
+++ b/src/claude_anyteam/env.py
@@ -45,6 +45,8 @@ LEGACY_NON_PROGRESS_WARN_ENV = "CODEX_TEAMMATE_NON_PROGRESS_WARN_S"
 NON_PROGRESS_INTERRUPT_ENV = "CLAUDE_ANYTEAM_NON_PROGRESS_INTERRUPT_S"
 LEGACY_NON_PROGRESS_INTERRUPT_ENV = "CODEX_TEAMMATE_NON_PROGRESS_INTERRUPT_S"
 
+WRAPPER_TOOL_FAILURE_WINDOW_ENV = "CLAUDE_ANYTEAM_WRAPPER_TOOL_FAILURE_WINDOW_S"
+
 # Codex App Server JSON-RPC ``initialize`` budget (#40 Phase 1).
 # Default 90s — chosen because the only successful empirical sample we
 # have (codex-reviewer turn 1, parking-ack prompt, ~17s) is well under

--- a/src/claude_anyteam/loop.py
+++ b/src/claude_anyteam/loop.py
@@ -563,6 +563,7 @@ def _invoke_codex_prose(
                 overall_timeout_s=s.turn_timeout_s,
                 non_progress_warn_s=s.non_progress_warn_s,
                 non_progress_interrupt_s=s.non_progress_interrupt_s,
+                wrapper_tool_failure_window_s=s.wrapper_tool_failure_window_s,
                 event_sink=event_sink,
                 # No resume_thread_id — ephemeral, not chained to task lineage.
             )
@@ -1831,6 +1832,7 @@ def _execute_task_app_server(state: LoopState, task, prompt: str):
         overall_timeout_s=s.turn_timeout_s,
         non_progress_warn_s=s.non_progress_warn_s,
         non_progress_interrupt_s=s.non_progress_interrupt_s,
+        wrapper_tool_failure_window_s=s.wrapper_tool_failure_window_s,
         resume_thread_id=state.app_server_last_thread_id,
         task_id=str(task.id),
         event_sink=_visibility_event_sink,

--- a/src/claude_anyteam/messages.py
+++ b/src/claude_anyteam/messages.py
@@ -284,6 +284,12 @@ KNOWN_TASK_BLOCKED_REASONS: frozenset[str] = frozenset(
         # shutdown burning the budget vs a work-turn timeout uniformly
         # in their dashboard, but with separate filters.
         "app_server_shutdown_timeout",
+        # #49 / RFC §5.1: a wrapper MCP tool failed and no recovery
+        # activity appeared within the configured discriminator window.
+        # This is a lead-action token, not a diagnostics.ERROR_CLASSES entry:
+        # the envelope itself is an in-flight signal rather than a terminal
+        # turn failure.
+        "wrapper_tool_failure_unrecovered",
     }
 )
 
@@ -392,6 +398,11 @@ VisibilityEventKind = Literal[
     # silence; carries ``attempt``, ``elapsed_s``, ``last_observed_pid``,
     # and (Linux only, best-effort) ``last_observed_cpu_pct``.
     "app_server_initialize_progress",
+    # #49 / RFC §5.1: wrapper MCP tool failure followed by no observable
+    # turn_progress/tool_event/artifact_event/agentMessage_delta within W.
+    # This is a top-level signal, not ``visibility_degraded`` and not a
+    # diagnostics.ERROR_CLASSES terminal failure.
+    "wrapper_tool_failure_unrecovered",
 ]
 
 VisibilitySeverity = Literal["debug", "info", "warn", "error"]
@@ -502,6 +513,7 @@ def parse_protocol_text(text: str) -> _Base | None:
         "batch_summary",
         "app_server_initialize_completed",
         "app_server_initialize_progress",
+        "wrapper_tool_failure_unrecovered",
     }:
         return _safe_load(VisibilityEvent, raw)
     return None

--- a/src/claude_anyteam/spawn_shim.py
+++ b/src/claude_anyteam/spawn_shim.py
@@ -110,6 +110,7 @@ _AGENT_CONFIG_KEYS = (
     "turn_timeout_s",
     "non_progress_warn_s",
     "non_progress_interrupt_s",
+    "wrapper_tool_failure_window_s",
 )
 
 
@@ -358,6 +359,13 @@ def _adapter_argv(
     if include_watchdog and "non_progress_interrupt_s" in agent_config:
         argv.extend(
             ["--non-progress-interrupt-s", agent_config["non_progress_interrupt_s"]]
+        )
+    if include_watchdog and "wrapper_tool_failure_window_s" in agent_config:
+        argv.extend(
+            [
+                "--wrapper-tool-failure-window-s",
+                agent_config["wrapper_tool_failure_window_s"],
+            ]
         )
     return argv, agent_config
 

--- a/src/claude_anyteam/team_cli.py
+++ b/src/claude_anyteam/team_cli.py
@@ -53,6 +53,7 @@ AGENT_CONFIG_KEYS = (
     "turn_timeout_s",
     "non_progress_warn_s",
     "non_progress_interrupt_s",
+    "wrapper_tool_failure_window_s",
 )
 
 # Default post-spawn agentType for codex-/gemini-/kimi- teammates. The Agent
@@ -177,6 +178,15 @@ def _build_team_agent_parser() -> argparse.ArgumentParser:
         ),
     )
     p.add_argument(
+        "--wrapper-tool-failure-window-s",
+        type=float,
+        help=(
+            "Codex App Server wrapper-tool recovery discriminator window in "
+            "seconds. Range [60, 300], default 90. Forwarded to the adapter "
+            "as --wrapper-tool-failure-window-s."
+        ),
+    )
+    p.add_argument(
         "--remove",
         action="store_true",
         help="Delete the per-teammate config file instead of writing one",
@@ -215,11 +225,13 @@ def _team_agent_command(argv: list[str], *, stdout: TextIO | None = None, stderr
         and args.turn_timeout_s is None
         and args.non_progress_warn_s is None
         and args.non_progress_interrupt_s is None
+        and args.wrapper_tool_failure_window_s is None
     ):
         err.write(
             "error: at least one of --model/--effort/--turn-timeout-s/"
-            "--non-progress-warn-s/--non-progress-interrupt-s must be provided "
-            "(or use --remove to delete)\n"
+            "--non-progress-warn-s/--non-progress-interrupt-s/"
+            "--wrapper-tool-failure-window-s must be provided (or use --remove "
+            "to delete)\n"
         )
         return 2
 
@@ -244,6 +256,14 @@ def _team_agent_command(argv: list[str], *, stdout: TextIO | None = None, stderr
             f"got {args.non_progress_interrupt_s}\n"
         )
         return 2
+    if args.wrapper_tool_failure_window_s is not None and not (
+        60.0 <= args.wrapper_tool_failure_window_s <= 300.0
+    ):
+        err.write(
+            "error: --wrapper-tool-failure-window-s must be in [60, 300] "
+            f"seconds, got {args.wrapper_tool_failure_window_s}\n"
+        )
+        return 2
 
     config = _existing_dict(path)
     config = {k: v for k, v in config.items() if k in AGENT_CONFIG_KEYS}
@@ -258,6 +278,10 @@ def _team_agent_command(argv: list[str], *, stdout: TextIO | None = None, stderr
         config["non_progress_warn_s"] = args.non_progress_warn_s
     if args.non_progress_interrupt_s is not None:
         config["non_progress_interrupt_s"] = args.non_progress_interrupt_s
+    if args.wrapper_tool_failure_window_s is not None:
+        config["wrapper_tool_failure_window_s"] = (
+            args.wrapper_tool_failure_window_s
+        )
 
     _write_atomic_json(path, config)
 
@@ -412,6 +436,7 @@ class _RosterRow:
     adapter_turn_timeout_s: float | None = None
     adapter_non_progress_warn_s: float | None = None
     adapter_non_progress_interrupt_s: float | None = None
+    adapter_wrapper_tool_failure_window_s: float | None = None
     config_source: str | None = None
     # 09 R11 / 08 §6.3 cheap capability flags; rich Agent Card
     # manifests are intentionally not expanded in the roster table.
@@ -472,6 +497,7 @@ def _roster_rows(cfg: dict[str, object], *, team: str | None = None, resolve: bo
         adapter_turn_timeout_s: float | None = None
         adapter_non_progress_warn_s: float | None = None
         adapter_non_progress_interrupt_s: float | None = None
+        adapter_wrapper_tool_failure_window_s: float | None = None
         config_source: str | None = None
         if resolve and team is not None:
             agent_cfg, source = _read_agent_config(team, name)
@@ -495,6 +521,12 @@ def _roster_rows(cfg: dict[str, object], *, team: str | None = None, resolve: bo
                     adapter_non_progress_interrupt_s = float(npi)
                 except (TypeError, ValueError):
                     adapter_non_progress_interrupt_s = None
+            wtf = agent_cfg.get("wrapper_tool_failure_window_s")
+            if wtf is not None:
+                try:
+                    adapter_wrapper_tool_failure_window_s = float(wtf)
+                except (TypeError, ValueError):
+                    adapter_wrapper_tool_failure_window_s = None
             config_source = source
         capability_version = _manifest_version_for_agent(team, name) if resolve and team is not None else None
         adapter_pid = _latest_wrapper_diag_pid(team, name) if resolve and team is not None else None
@@ -517,6 +549,9 @@ def _roster_rows(cfg: dict[str, object], *, team: str | None = None, resolve: bo
                 adapter_turn_timeout_s=adapter_turn_timeout_s,
                 adapter_non_progress_warn_s=adapter_non_progress_warn_s,
                 adapter_non_progress_interrupt_s=adapter_non_progress_interrupt_s,
+                adapter_wrapper_tool_failure_window_s=(
+                    adapter_wrapper_tool_failure_window_s
+                ),
                 config_source=config_source,
                 capabilities=capabilities,
                 tmux_pane_id=str(m.get("tmuxPaneId", "")),
@@ -675,6 +710,7 @@ def _team_roster_command(argv: list[str], *, stdout: TextIO | None = None, stder
             or r.adapter_turn_timeout_s is not None
             or r.adapter_non_progress_warn_s is not None
             or r.adapter_non_progress_interrupt_s is not None
+            or r.adapter_wrapper_tool_failure_window_s is not None
         ):
             parts = []
             if r.adapter_model:
@@ -691,6 +727,11 @@ def _team_roster_command(argv: list[str], *, stdout: TextIO | None = None, stder
                 parts.append(
                     "adapter_non_progress_interrupt_s="
                     f"{r.adapter_non_progress_interrupt_s}"
+                )
+            if r.adapter_wrapper_tool_failure_window_s is not None:
+                parts.append(
+                    "adapter_wrapper_tool_failure_window_s="
+                    f"{r.adapter_wrapper_tool_failure_window_s}"
                 )
             adapter_suffix = "  " + " ".join(parts)
         capabilities_suffix = f"  capabilities={_format_capabilities(r.capabilities)}"
@@ -815,6 +856,9 @@ def _team_config_command(argv: list[str], *, stdout: TextIO | None = None, stder
         "adapter_turn_timeout_s": agent_cfg.get("turn_timeout_s"),
         "adapter_non_progress_warn_s": agent_cfg.get("non_progress_warn_s"),
         "adapter_non_progress_interrupt_s": agent_cfg.get("non_progress_interrupt_s"),
+        "adapter_wrapper_tool_failure_window_s": agent_cfg.get(
+            "wrapper_tool_failure_window_s"
+        ),
         "config_source": source,
     }
 
@@ -835,7 +879,9 @@ def _team_config_command(argv: list[str], *, stdout: TextIO | None = None, stder
             f"turn_timeout_s={resolved['adapter_turn_timeout_s']!r} "
             f"non_progress_warn_s={resolved['adapter_non_progress_warn_s']!r} "
             "non_progress_interrupt_s="
-            f"{resolved['adapter_non_progress_interrupt_s']!r}\n"
+            f"{resolved['adapter_non_progress_interrupt_s']!r} "
+            "wrapper_tool_failure_window_s="
+            f"{resolved['adapter_wrapper_tool_failure_window_s']!r}\n"
         )
         out.write(f"source : {source}\n")
     return 0

--- a/tests/test_app_server_default.py
+++ b/tests/test_app_server_default.py
@@ -45,6 +45,7 @@ def test_default_app_server_is_on():
     assert s.turn_timeout_s == 1800.0
     assert s.non_progress_warn_s is None
     assert s.non_progress_interrupt_s is None
+    assert s.wrapper_tool_failure_window_s == 90.0
 
 
 def test_env_opt_out_honored():
@@ -218,3 +219,37 @@ def test_cli_parses_non_progress_flags():
     )
     assert ns.non_progress_warn_s == 180
     assert ns.non_progress_interrupt_s == 420
+
+
+def test_wrapper_tool_failure_window_env_and_overrides_are_honored():
+    os.environ["CLAUDE_ANYTEAM_WRAPPER_TOOL_FAILURE_WINDOW_S"] = "120"
+    try:
+        s = from_env(overrides=_baseline_overrides())
+        assert s.wrapper_tool_failure_window_s == 120.0
+
+        overrides = _baseline_overrides() | {"wrapper_tool_failure_window_s": 240}
+        s = from_env(overrides=overrides)
+        assert s.wrapper_tool_failure_window_s == 240.0
+    finally:
+        del os.environ["CLAUDE_ANYTEAM_WRAPPER_TOOL_FAILURE_WINDOW_S"]
+
+
+def test_wrapper_tool_failure_window_range_is_validated():
+    with pytest.raises(ValueError, match="wrapper_tool_failure_window_s"):
+        from_env(overrides=_baseline_overrides() | {"wrapper_tool_failure_window_s": 59})
+    with pytest.raises(ValueError, match="wrapper_tool_failure_window_s"):
+        from_env(overrides=_baseline_overrides() | {"wrapper_tool_failure_window_s": 301})
+
+
+def test_cli_parses_wrapper_tool_failure_window_flag():
+    ns = cli_mod._parse_args(
+        [
+            "--team",
+            "t",
+            "--name",
+            "a",
+            "--wrapper-tool-failure-window-s",
+            "120",
+        ]
+    )
+    assert ns.wrapper_tool_failure_window_s == 120

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -24,6 +24,7 @@ from claude_anyteam.messages import (
     TaskAssignmentIn,
     TaskCompleteOut,
     VisibilityEvent,
+    KNOWN_TASK_BLOCKED_REASONS,
     parse_protocol_text,
 )
 
@@ -239,6 +240,33 @@ def test_parse_batch_summary_visibility_event():
     assert isinstance(parsed, VisibilityEvent)
     assert parsed.kind == "batch_summary"
     assert parsed.payload["parentTaskId"] == "40"
+
+
+def test_parse_wrapper_tool_failure_unrecovered_visibility_event():
+    event = VisibilityEvent(
+        kind="wrapper_tool_failure_unrecovered",
+        event_id="worker:turn-1:000003",
+        team="team-x",
+        agent="worker",
+        backend="codex_app_server",
+        task_id="49",
+        turn_id="turn-1",
+        seq=3,
+        severity="warn",
+        summary="wrapper tool failed without recovery",
+        payload={
+            "tool_name": "mcp_anyteam_read_file",
+            "error_class": "enoent",
+            "silence_window_ms": 90000,
+            "recovery_hint_dispatched": False,
+        },
+    )
+
+    parsed = parse_protocol_text(event.model_dump_json(by_alias=True, exclude_none=True))
+
+    assert isinstance(parsed, VisibilityEvent)
+    assert parsed.kind == "wrapper_tool_failure_unrecovered"
+    assert "wrapper_tool_failure_unrecovered" in KNOWN_TASK_BLOCKED_REASONS
 
 
 def test_parse_typed_lifecycle_payload_variants():

--- a/tests/test_spawn_shim.py
+++ b/tests/test_spawn_shim.py
@@ -429,7 +429,11 @@ def test_agent_config_forwards_non_progress_watchdog_flags(monkeypatch, tmp_path
         tmp_path,
         "build",
         "codex-alice",
-        {"non_progress_warn_s": 180, "non_progress_interrupt_s": 420},
+        {
+            "non_progress_warn_s": 180,
+            "non_progress_interrupt_s": 420,
+            "wrapper_tool_failure_window_s": 120,
+        },
     )
     calls, stderr = _codex_argv_for(monkeypatch, tmp_path, "build", "codex-alice", capsys)
 
@@ -444,11 +448,14 @@ def test_agent_config_forwards_non_progress_watchdog_flags(monkeypatch, tmp_path
         "180",
         "--non-progress-interrupt-s",
         "420",
+        "--wrapper-tool-failure-window-s",
+        "120",
     ]
     log = json.loads(stderr.strip())
     assert log["agent_config"] == {
         "non_progress_warn_s": "180",
         "non_progress_interrupt_s": "420",
+        "wrapper_tool_failure_window_s": "120",
     }
 
 
@@ -663,7 +670,11 @@ def test_gemini_dispatch_does_not_forward_codex_watchdog_flags(monkeypatch, tmp_
         tmp_path,
         "t",
         "gemini-pro",
-        {"non_progress_warn_s": 180, "non_progress_interrupt_s": 420},
+        {
+            "non_progress_warn_s": 180,
+            "non_progress_interrupt_s": 420,
+            "wrapper_tool_failure_window_s": 120,
+        },
     )
     calls = _record_execv(monkeypatch)
     monkeypatch.setenv("HOME", str(tmp_path))
@@ -683,9 +694,11 @@ def test_gemini_dispatch_does_not_forward_codex_watchdog_flags(monkeypatch, tmp_
     _, argv = calls[0]
     assert "--non-progress-warn-s" not in argv
     assert "--non-progress-interrupt-s" not in argv
+    assert "--wrapper-tool-failure-window-s" not in argv
     assert json.loads(capsys.readouterr().err)["agent_config"] == {
         "non_progress_warn_s": "180",
         "non_progress_interrupt_s": "420",
+        "wrapper_tool_failure_window_s": "120",
     }
 
 

--- a/tests/test_task_blocked_reason_drift.py
+++ b/tests/test_task_blocked_reason_drift.py
@@ -259,13 +259,20 @@ def test_free_form_prose_reason_is_silent(identity: Path) -> None:
     )
 
 
-def test_registry_includes_both_phase_1_tokens() -> None:
+def test_registry_includes_visibility_action_tokens() -> None:
     """Pin: both #40 Phase 1 tokens are in the registry. If they were
     missing, every legitimate task_blocked emission from the codex loop
     would trigger a drift warn — defeating the §2 invariant.
     """
     assert "app_server_initialize_timeout" in KNOWN_TASK_BLOCKED_REASONS
     assert "app_server_shutdown_timeout" in KNOWN_TASK_BLOCKED_REASONS
+    assert "wrapper_tool_failure_unrecovered" in KNOWN_TASK_BLOCKED_REASONS
+
+
+def test_wrapper_tool_failure_signal_is_not_terminal_error_class() -> None:
+    from claude_anyteam.diagnostics import ERROR_CLASSES
+
+    assert "wrapper_tool_failure_unrecovered" not in ERROR_CLASSES
 
 
 def test_recipient_parses_typed_task_blocked_via_discriminator(

--- a/tests/test_team_cli.py
+++ b/tests/test_team_cli.py
@@ -84,6 +84,23 @@ def test_team_agent_writes_non_progress_watchdog_keys(fake_home, capsys):
     assert "non_progress_interrupt_s=420.0" in out
 
 
+def test_team_agent_writes_wrapper_tool_failure_window(fake_home, capsys):
+    rc = cli_main(
+        [
+            "team-agent",
+            "codex-alice",
+            "--team",
+            "build",
+            "--wrapper-tool-failure-window-s",
+            "120",
+        ]
+    )
+    assert rc == 0
+    cfg = json.loads(_agent_path(fake_home, "build", "codex-alice").read_text())
+    assert cfg == {"wrapper_tool_failure_window_s": 120.0}
+    assert "wrapper_tool_failure_window_s=120.0" in capsys.readouterr().out
+
+
 def test_team_agent_neither_model_nor_effort_is_an_error(fake_home, capsys):
     rc = cli_main(["team-agent", "codex-alice", "--team", "build"])
     assert rc == 2
@@ -174,6 +191,19 @@ def test_team_agent_invalid_non_progress_values_are_rejected(fake_home, capsys):
     )
     assert rc == 2
     assert "--non-progress-interrupt-s" in capsys.readouterr().err
+
+    rc = cli_main(
+        [
+            "team-agent",
+            "codex-alice",
+            "--team",
+            "build",
+            "--wrapper-tool-failure-window-s",
+            "30",
+        ]
+    )
+    assert rc == 2
+    assert "--wrapper-tool-failure-window-s" in capsys.readouterr().err
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_visibility_events.py
+++ b/tests/test_visibility_events.py
@@ -617,6 +617,167 @@ def test_app_server_interrupt_fires_when_warn_none(monkeypatch):
     assert created[0].steers == [], "warn=None must not steer"
 
 
+def test_wrapper_tool_failure_unrecovered_emits_after_quiet_window(monkeypatch):
+    class Clock:
+        now = 0.0
+
+        def monotonic(self):
+            return self.now
+
+    class AdvancingQueue:
+        def __init__(self, items: list[dict], clock: Clock):
+            self.items = list(items)
+            self.clock = clock
+
+        def get(self, timeout=None):
+            if self.items:
+                item = self.items.pop(0)
+                if "__advance__" in item:
+                    self.clock.now += float(item["__advance__"])
+                    raise RuntimeError("empty (test)")
+                return item
+            raise RuntimeError("empty (test)")
+
+    clock = Clock()
+    notifications = [
+        {
+            "method": "item/completed",
+            "params": {
+                "item": {
+                    "type": "mcpToolCall",
+                    "server": "claude_anyteam_wrapper",
+                    "tool": "mcp_anyteam_read_file",
+                    "status": "failed",
+                    "error": "[Errno 2] No such file or directory: '/missing'",
+                }
+            },
+        },
+        {"__advance__": 91},
+        {"method": "turn/completed", "params": {"turn": {"status": "ok"}}},
+    ]
+
+    class Client(_FakeClient):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, notifications=[], **kwargs)
+            self.notifications = AdvancingQueue(notifications, clock)
+
+    emitted: list[VisibilityEvent] = []
+    with (
+        patch.object(app_server_mod, "AppServerClient", Client),
+        monkeypatch.context() as m,
+    ):
+        m.setattr(codex_mod.time, "monotonic", clock.monotonic)
+        result = codex_mod.app_server_invoke(
+            task_prompt="read missing file",
+            cwd=Path("/tmp"),
+            schema=None,
+            settings_team="team-x",
+            settings_agent="codex-runtime",
+            task_id="49",
+            overall_timeout_s=900,
+            non_progress_warn_s=300,
+            wrapper_tool_failure_window_s=90,
+            event_sink=emitted.append,
+        )
+
+    assert result.exit_code == 0
+    unrecovered = [
+        e for e in emitted if e.kind == "wrapper_tool_failure_unrecovered"
+    ]
+    assert len(unrecovered) == 1
+    event = unrecovered[0]
+    assert event.visibility.mailbox is True
+    assert event.visibility.task_state is True
+    assert event.payload["tool_name"] == "mcp_anyteam_read_file"
+    assert event.payload["error_class"] == "enoent"
+    assert event.payload["silence_window_ms"] == 90000
+    assert event.payload["recovery_hint_dispatched"] is False
+
+
+def test_wrapper_tool_failure_recovered_by_later_tool_event_suppresses_signal(
+    monkeypatch,
+):
+    class Clock:
+        now = 0.0
+
+        def monotonic(self):
+            return self.now
+
+    class AdvancingQueue:
+        def __init__(self, items: list[dict], clock: Clock):
+            self.items = list(items)
+            self.clock = clock
+
+        def get(self, timeout=None):
+            if self.items:
+                item = self.items.pop(0)
+                if "__advance__" in item:
+                    self.clock.now += float(item["__advance__"])
+                    raise RuntimeError("empty (test)")
+                return item
+            raise RuntimeError("empty (test)")
+
+    clock = Clock()
+    notifications = [
+        {
+            "method": "item/completed",
+            "params": {
+                "item": {
+                    "type": "mcpToolCall",
+                    "server": "claude_anyteam_wrapper",
+                    "tool": "task_update",
+                    "status": "failed",
+                    "error": "bad task id",
+                }
+            },
+        },
+        {"__advance__": 30},
+        {
+            "method": "item/completed",
+            "params": {
+                "item": {
+                    "type": "mcpToolCall",
+                    "server": "claude_anyteam_wrapper",
+                    "tool": "task_list",
+                    "status": "completed",
+                }
+            },
+        },
+        {"__advance__": 91},
+        {"method": "turn/completed", "params": {"turn": {"status": "ok"}}},
+    ]
+
+    class Client(_FakeClient):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, notifications=[], **kwargs)
+            self.notifications = AdvancingQueue(notifications, clock)
+
+    emitted: list[VisibilityEvent] = []
+    with (
+        patch.object(app_server_mod, "AppServerClient", Client),
+        monkeypatch.context() as m,
+    ):
+        m.setattr(codex_mod.time, "monotonic", clock.monotonic)
+        result = codex_mod.app_server_invoke(
+            task_prompt="recover from bad update",
+            cwd=Path("/tmp"),
+            schema=None,
+            settings_team="team-x",
+            settings_agent="codex-runtime",
+            task_id="49",
+            overall_timeout_s=900,
+            non_progress_warn_s=300,
+            wrapper_tool_failure_window_s=90,
+            event_sink=emitted.append,
+        )
+
+    assert result.exit_code == 0
+    assert not [
+        e for e in emitted if e.kind == "wrapper_tool_failure_unrecovered"
+    ]
+
+
+
 def test_app_server_watchdog_fans_out_to_event_log_mailbox_and_active_form(
     events_root: Path,
     monkeypatch,


### PR DESCRIPTION
## Summary
- add top-level `wrapper_tool_failure_unrecovered` visibility kind for #49
- implement Codex App Server Mode A/B discriminator: after a failed wrapper MCP tool event, emit only if no later `turn_progress`/`tool_event`/`artifact_event`/agentMessage delta appears within W
- expose W as `--wrapper-tool-failure-window-s`, `CLAUDE_ANYTEAM_WRAPPER_TOOL_FAILURE_WINDOW_S`, and per-teammate `wrapper_tool_failure_window_s`
- register the lead-action `KNOWN_TASK_BLOCKED_REASONS` token while deliberately leaving `diagnostics.ERROR_CLASSES` untouched
- document the new configuration surface

## Tests
- `uv run pytest -q` — 1142 passed, 11 skipped, 2 deselected
- targeted pre-full-suite checks also passed for config/parser/taxonomy/spawn-shim/team-cli and the Mode A/B discriminator tests

Refs #49
