### PR TITLE
fix(#48 + #49 follow-up): override-audit event + boundary tests + capability manifest + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,13 @@ All notable changes to claude-anyteam are documented here. Format follows [Keep 
 
 ## [Unreleased]
 
+### Added
+
+- **`wrapper_tool_failure_unrecovered` visibility envelope** (issue #49 / PR #60) surfaces Codex App Server wrapper-MCP tool failures that are not followed by `turn_progress`, `tool_event`, or `artifact_event` recovery activity within the discriminator window. The window is configurable with `--wrapper-tool-failure-window-s`, `CLAUDE_ANYTEAM_WRAPPER_TOOL_FAILURE_WINDOW_S`, and the per-teammate agents-file key `wrapper_tool_failure_window_s`.
+
 ### Changed
 
+- **Breaking #48 routed-prefix spawn guard:** spawning a `codex-*`, `gemini-*`, or `kimi-*` teammate without a matching per-teammate agents-file config now exits 2 with `spawn_shim.bare_prefix_refused` instead of silently proceeding to adapter defaults. Set `CLAUDE_ANYTEAM_ALLOW_BARE_PREFIX=1` only when you intentionally want the old bare-prefix default behavior; that override is now audited with `spawn_shim.bare_prefix_allowed_via_override`.
 - **`turn_timeout_s` default bumped 900 → 1800s** (task #5). The prior 900s cap interrupted legitimately long Codex turns (large test suites, multi-file refactors at `xhigh` effort) and was the dominant pain the visibility-driven RFC at `docs/design/timers-vs-visibility.md` (issue #50) was written to address. Cap remains 3600s — no single turn should run longer than an hour. Affects Codex App Server (`turn_timeout_s`), Codex Exec, and `claude-native` (`CLAUDE_ANYTEAM_CLAUDE_TURN_TIMEOUT_S`). Set `--turn-timeout-s 900` or `CLAUDE_ANYTEAM_TURN_TIMEOUT_S=900` to restore the prior default for any single teammate.
 - **`non_progress_warn_s` default flipped from 300s to None (opt-in)** (task #5 / RFC #50 Phase B). The soft non-progress watchdog now ships disabled by default. Lead reads typed visibility events instead — see `docs/design/timers-vs-visibility.md` for the migration plan and the new envelope taxonomy. Existing users who want the prior behavior set `--non-progress-warn-s 300` or `CLAUDE_ANYTEAM_NON_PROGRESS_WARN_S=300`.
 - **`non_progress_warn_s` range upper bumped 900 → 1800s** so opt-in users can scale the watchdog proportionally to the new `turn_timeout_s` default. Range now `[60, 1800]` when explicitly set.

--- a/src/claude_anyteam/capabilities.py
+++ b/src/claude_anyteam/capabilities.py
@@ -29,6 +29,7 @@ CAPABILITY_NAMES = frozenset(
         "large_context",
         "accepts_peer_steer",
         "soft_non_progress_watchdog",
+        "wrapper_tool_failure_discriminator",
     }
 )
 
@@ -40,6 +41,7 @@ CODEX_APP_SERVER_CAPABILITIES = [
     "structured_output",
     "plan_mode",
     "soft_non_progress_watchdog",
+    "wrapper_tool_failure_discriminator",
     # Q4 (per opus-arch-impl): Codex App Server is deliberately lead-only
     # for peer steer until the handler and runtime behavior are re-reviewed.
 ]
@@ -106,6 +108,7 @@ _CAPABILITY_DISPLAY_NAMES = {
     "large_context": "large context (`large_context`)",
     "accepts_peer_steer": "peer steer acceptance (`accepts_peer_steer`)",
     "soft_non_progress_watchdog": "soft non-progress watchdog (`soft_non_progress_watchdog`)",
+    "wrapper_tool_failure_discriminator": "wrapper-tool failure discriminator (`wrapper_tool_failure_discriminator`)",
 }
 
 
@@ -302,6 +305,22 @@ CAPABILITY_HOOKS: dict[str, CapabilityRuntimeHook] = {
             "tests/test_app_server_default.py::test_non_progress_env_and_overrides_are_honored",
         ),
         note="Codex App Server turns emit non-progress warnings and optional interrupts.",
+    ),
+    "wrapper_tool_failure_discriminator": CapabilityRuntimeHook(
+        runtime_paths=(
+            "claude_anyteam.codex:app_server_invoke",
+            "claude_anyteam.wrapper_tool_failure:is_wrapper_tool_recovery_event_kind",
+            "claude_anyteam.config:Settings",
+        ),
+        test_paths=(
+            "tests/test_visibility_events.py::test_wrapper_tool_failure_unrecovered_emits_after_quiet_window",
+            "tests/test_visibility_events.py::test_wrapper_tool_failure_multi_failure_series_emits_one_terminal_envelope",
+            "tests/test_app_server_default.py::test_wrapper_tool_failure_window_env_and_overrides_are_honored",
+        ),
+        note=(
+            "Codex App Server emits wrapper_tool_failure_unrecovered after the "
+            "configured discriminator window and debounces same-tool retry loops."
+        ),
     ),
 }
 
@@ -615,6 +634,51 @@ _BASE_CAPABILITY_MANIFEST: dict[str, dict[str, Any]] = {
             "WATCHDOG_WARNING_SENT",
             "WATCHDOG_STEER_FAILED",
             "WATCHDOG_INTERRUPT_SENT",
+        ],
+        "callable_from_peers": False,
+    },
+    "wrapper_tool_failure_discriminator": {
+        "version": "1",
+        "schema": {
+            "type": "object",
+            "properties": {
+                "wrapper_tool_failure_window_s": {
+                    "type": "number",
+                    "default": 90,
+                    "minimum": 60,
+                    "maximum": 300,
+                },
+                "recovery_event_kinds": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "default": ["turn_progress", "tool_event", "artifact_event"],
+                },
+                "debounce_key": {
+                    "type": "string",
+                    "const": "tool_name",
+                },
+            },
+        },
+        "description": (
+            "Discriminate Codex App Server wrapper-MCP tool failures that are "
+            "not followed by recovery activity within the configured window, "
+            "then emit wrapper_tool_failure_unrecovered as a lead-actionable "
+            "visibility envelope."
+        ),
+        "when_to_use": (
+            "Prefer this teammate for long-running Codex App Server work where "
+            "wrapper MCP failures such as missing files or bad task ids should "
+            "be visible before turn completion."
+        ),
+        "when_not_to": (
+            "Not directly callable by peers. Do not declare it for Codex exec, "
+            "Gemini, or Kimi until those backends expose the same live wrapper "
+            "tool event stream and discriminator window."
+        ),
+        "failure_modes": [
+            "WRAPPER_TOOL_FAILURE_UNRECOVERED",
+            "WRAPPER_TOOL_FAILURE_RECOVERED_BY_PROGRESS",
+            "WRAPPER_TOOL_FAILURE_DEBOUNCED_BY_TOOL_NAME",
         ],
         "callable_from_peers": False,
     },

--- a/src/claude_anyteam/codex.py
+++ b/src/claude_anyteam/codex.py
@@ -56,6 +56,11 @@ from .codex_log_bloat import (
 from .headless_visibility import HeadlessTurnVisibility, coerce_stream_text
 from .messages import VisibilityEvent
 from .prompts import TEAM_MESSAGING_BLOCK
+from .wrapper_tool_failure import (
+    WRAPPER_TOOL_RECOVERY_EVENT_KINDS,
+    is_wrapper_tool_recovery_event_kind,
+    visibility_event_counts_as_wrapper_tool_recovery,
+)
 from .wrapper_mcp_diagnostics import append_wrapper_mcp_diagnostic
 
 # R1 (09 §3.1): schema files are versioned wire
@@ -141,11 +146,6 @@ _WRAPPER_EXPECTED_TOOL_NAMES = (
 # mcp_anyteam_read_file ENOENT) participate in the same recovery logic as
 # core team tools.
 _WRAPPER_TOOL_NAMES = frozenset(_WRAPPER_EXPECTED_TOOL_NAMES)
-
-_WRAPPER_TOOL_RECOVERY_EVENT_KINDS = frozenset(
-    {"turn_progress", "tool_event", "artifact_event"}
-)
-
 
 @dataclass
 class _PendingWrapperToolFailure:
@@ -1646,6 +1646,7 @@ def app_server_invoke(
     turn_started_at: float | None = None
     visibility_seq = 0
     pending_wrapper_tool_failures: list[_PendingWrapperToolFailure] = []
+    emitted_unrecovered_wrapper_tools: set[str] = set()
 
     def _emit_visibility_event(
         *,
@@ -1680,7 +1681,7 @@ def app_server_invoke(
                 "payload": payload,
             }
         )
-        if event.kind in _WRAPPER_TOOL_RECOVERY_EVENT_KINDS:
+        if visibility_event_counts_as_wrapper_tool_recovery(event):
             recovered_at = time.monotonic()
             for pending in pending_wrapper_tool_failures:
                 if (
@@ -1798,7 +1799,7 @@ def app_server_invoke(
                 payload=checkpoint_payload,
             )
 
-    def _record(ev: dict[str, Any]) -> None:
+    def _record(ev: dict[str, Any]) -> VisibilityEvent | None:
         nonlocal tool_call_events
         events.append(ev)
         method = str(ev.get("method", ""))
@@ -1825,7 +1826,7 @@ def app_server_invoke(
             )
             if _is_failed_wrapper_tool_event(visibility_event):
                 if visibility_event is None:
-                    return
+                    return None
                 pending_wrapper_tool_failures.append(
                     _PendingWrapperToolFailure(
                         failed_event_id=visibility_event.event_id,
@@ -1841,6 +1842,8 @@ def app_server_invoke(
                         turn_id=visibility_event.turn_id,
                     )
                 )
+            return visibility_event
+        return None
 
     # MCP config for the wrapper — same shape as the exec path, injected via
     # Codex's config override mechanism on thread start. App Server accepts
@@ -2052,14 +2055,41 @@ def app_server_invoke(
             """
 
             for pending in pending_wrapper_tool_failures:
+                if pending.tool_name in emitted_unrecovered_wrapper_tools:
+                    pending.emitted = True
+                    continue
+                later_same_tool = [
+                    candidate
+                    for candidate in pending_wrapper_tool_failures
+                    if (
+                        candidate.tool_name == pending.tool_name
+                        and candidate.failed_event_seq > pending.failed_event_seq
+                        and candidate.recovered_at_monotonic is None
+                        and not candidate.emitted
+                    )
+                ]
                 if (
                     pending.emitted
                     or pending.recovered_at_monotonic is not None
+                    or later_same_tool
                     or (now - pending.failed_at_monotonic)
                     < wrapper_tool_failure_window_s
                 ):
                     continue
+                suppressed_same_tool = [
+                    candidate
+                    for candidate in pending_wrapper_tool_failures
+                    if (
+                        candidate.tool_name == pending.tool_name
+                        and candidate.failed_event_seq < pending.failed_event_seq
+                        and candidate.recovered_at_monotonic is None
+                        and not candidate.emitted
+                    )
+                ]
+                for candidate in suppressed_same_tool:
+                    candidate.emitted = True
                 pending.emitted = True
+                emitted_unrecovered_wrapper_tools.add(pending.tool_name)
                 silence_window_ms = int(wrapper_tool_failure_window_s * 1000)
                 payload: dict[str, Any] = {
                     "tool_name": pending.tool_name,
@@ -2073,6 +2103,11 @@ def app_server_invoke(
                     ),
                     "silence_window_ms": silence_window_ms,
                     "recovery_hint_dispatched": False,
+                    "recovery_event_kinds": sorted(
+                        WRAPPER_TOOL_RECOVERY_EVENT_KINDS
+                    ),
+                    "debounced_by": "tool_name",
+                    "suppressed_same_tool_failures": len(suppressed_same_tool),
                 }
                 payload = {k: v for k, v in payload.items() if v is not None}
                 _emit_visibility_event(
@@ -2527,7 +2562,7 @@ def app_server_invoke(
                             done = True
                             break
                 continue
-            _record(notif)
+            visibility_event = _record(notif)
             method = str(notif.get("method", ""))
             params = notif.get("params", {}) if isinstance(notif.get("params"), dict) else {}
             item = params.get("item") if isinstance(params, dict) else None
@@ -2541,7 +2576,15 @@ def app_server_invoke(
 
             # Watchdog progress signal: any tool_call_event delta or any
             # agentMessage byte-length delta counts as observable progress.
-            if tool_call_events > last_tool_count or len(last_message) > last_message_len:
+            # Wrapper-tool failure recovery uses the same visibility-kind
+            # helper so future recovery kinds cannot drift from this
+            # predicate.
+            tool_call_delta = tool_call_events > last_tool_count
+            agent_message_delta = len(last_message) > last_message_len
+            visibility_kind_delta = is_wrapper_tool_recovery_event_kind(
+                visibility_event.kind if visibility_event is not None else None
+            )
+            if tool_call_delta or agent_message_delta or visibility_kind_delta:
                 last_progress_at = time.monotonic()
                 last_tool_count = tool_call_events
                 last_message_len = len(last_message)

--- a/src/claude_anyteam/schemas/capability_manifest.schema.json
+++ b/src/claude_anyteam/schemas/capability_manifest.schema.json
@@ -115,7 +115,8 @@
           "structured_output",
           "thread_fork",
           "trust_modes",
-          "turn_steer"
+          "turn_steer",
+          "wrapper_tool_failure_discriminator"
         ]
       },
       "additionalProperties": {

--- a/src/claude_anyteam/spawn_shim.py
+++ b/src/claude_anyteam/spawn_shim.py
@@ -184,10 +184,38 @@ def _refuse_bare_routed_prefix(route: str, parsed: ParsedArgs) -> int:
     return 2
 
 
+def _emit_bare_prefix_override_event(route: str, parsed: ParsedArgs) -> None:
+    config_path = (
+        _agent_config_path(parsed.team_name, parsed.agent_name)
+        if parsed.team_name and parsed.agent_name
+        else None
+    )
+    message = (
+        f"Allowing bare {route} routed teammate {parsed.agent_name!r} because "
+        f"{ALLOW_BARE_PREFIX_ENV}=1 is set and no per-teammate config file "
+        "was found"
+    )
+    if config_path:
+        message += f" at {config_path}"
+    record: dict[str, object] = {
+        "event": "spawn_shim.bare_prefix_allowed_via_override",
+        "route": route,
+        "agent_name": parsed.agent_name,
+        "team_name": parsed.team_name,
+        "config_path": config_path,
+        "override_env": ALLOW_BARE_PREFIX_ENV,
+        "message": message,
+        "issue": "#48",
+    }
+    sys.stderr.write(json.dumps(record, sort_keys=True) + "\n")
+    sys.stderr.flush()
+
+
 def _maybe_refuse_bare_routed_prefix(route: str, parsed: ParsedArgs) -> int | None:
-    if _env_flag_enabled(ALLOW_BARE_PREFIX_ENV):
-        return None
     if _agent_config_exists(parsed.team_name, parsed.agent_name):
+        return None
+    if _env_flag_enabled(ALLOW_BARE_PREFIX_ENV):
+        _emit_bare_prefix_override_event(route, parsed)
         return None
     return _refuse_bare_routed_prefix(route, parsed)
 

--- a/src/claude_anyteam/wrapper_tool_failure.py
+++ b/src/claude_anyteam/wrapper_tool_failure.py
@@ -1,0 +1,25 @@
+"""Shared helpers for #49 wrapper-tool failure recovery semantics."""
+
+from __future__ import annotations
+
+from typing import Any
+
+WRAPPER_TOOL_RECOVERY_EVENT_KINDS = frozenset(
+    {"turn_progress", "tool_event", "artifact_event"}
+)
+
+
+def is_wrapper_tool_recovery_event_kind(kind: str | None) -> bool:
+    """Return True when a visibility kind counts as Mode-A recovery activity."""
+
+    return kind in WRAPPER_TOOL_RECOVERY_EVENT_KINDS
+
+
+def visibility_event_counts_as_wrapper_tool_recovery(event: Any | None) -> bool:
+    """Return True when an emitted visibility event closes pending failures.
+
+    Kept intentionally duck-typed to avoid importing the Pydantic event model
+    on hot paths; callers only need the stable ``.kind`` attribute.
+    """
+
+    return is_wrapper_tool_recovery_event_kind(getattr(event, "kind", None))

--- a/tests/test_capability_declarations.py
+++ b/tests/test_capability_declarations.py
@@ -47,6 +47,7 @@ def test_codex_app_server_backend_metadata_declares_expected_capabilities(tmp_pa
     assert "accepts_peer_steer" not in metadata.capabilities
     assert "plan_mode" in metadata.capabilities
     assert "soft_non_progress_watchdog" in metadata.capabilities
+    assert "wrapper_tool_failure_discriminator" in metadata.capabilities
     assert metadata.coupling_regime == "tight"
     assert metadata.capability_manifest["turn_steer"]["authorization"] == "lead_only"
     assert metadata.capability_manifest["turn_steer"]["callable_from_peers"] is False
@@ -56,6 +57,17 @@ def test_codex_app_server_backend_metadata_declares_expected_capabilities(tmp_pa
     # (default None) — see docs/design/timers-vs-visibility.md.
     assert watchdog["schema"]["properties"]["non_progress_warn_s"]["default"] is None
     assert watchdog["schema"]["properties"]["non_progress_warn_s"]["maximum"] == 1800
+    discriminator = metadata.capability_manifest[
+        "wrapper_tool_failure_discriminator"
+    ]
+    assert discriminator["callable_from_peers"] is False
+    assert (
+        discriminator["schema"]["properties"]["wrapper_tool_failure_window_s"][
+            "default"
+        ]
+        == 90
+    )
+    assert discriminator["schema"]["properties"]["debounce_key"]["const"] == "tool_name"
 
 
 def test_codex_app_server_metadata_advertises_native_host_tools_inventory(tmp_path: Path):
@@ -102,6 +114,7 @@ def test_codex_exec_backend_metadata_declares_headless_capabilities(tmp_path: Pa
     assert "structured_output" in metadata.capabilities
     assert "plan_mode" in metadata.capabilities
     assert "soft_non_progress_watchdog" not in metadata.capabilities
+    assert "wrapper_tool_failure_discriminator" not in metadata.capabilities
 
 
 def test_gemini_acp_backend_metadata_accepts_peer_steer(tmp_path: Path):

--- a/tests/test_spawn_shim.py
+++ b/tests/test_spawn_shim.py
@@ -509,6 +509,8 @@ def test_routed_prefix_without_agent_config_soft_refuses(monkeypatch, tmp_path, 
     assert log["override_env"] == "CLAUDE_ANYTEAM_ALLOW_BARE_PREFIX"
 
 
+# Former ``test_agent_config_missing_file_is_noop`` coverage lives in the
+# soft-refuse + explicit-override pair: missing configs are no longer a no-op.
 def test_bare_prefix_override_allows_dispatch_without_config(monkeypatch, tmp_path, capsys):
     calls = _record_execv(monkeypatch)
     _clear_binary_env(monkeypatch)
@@ -542,7 +544,18 @@ def test_bare_prefix_override_allows_dispatch_without_config(monkeypatch, tmp_pa
             ["/usr/local/bin/claude-anyteam", "--name", "codex-ghost", "--team", "t"],
         )
     ]
-    assert json.loads(capsys.readouterr().err)["route"] == "codex"
+    stderr_lines = capsys.readouterr().err.strip().splitlines()
+    assert [json.loads(line)["event"] for line in stderr_lines] == [
+        "spawn_shim.bare_prefix_allowed_via_override",
+        "spawn_shim.dispatch",
+    ]
+    override = json.loads(stderr_lines[0])
+    assert override["route"] == "codex"
+    assert override["agent_name"] == "codex-ghost"
+    assert override["team_name"] == "t"
+    assert override["config_path"].endswith("/.claude/teams/t/agents/codex-ghost.json")
+    assert override["override_env"] == "CLAUDE_ANYTEAM_ALLOW_BARE_PREFIX"
+    assert json.loads(stderr_lines[1])["route"] == "codex"
 
 
 def test_agent_config_malformed_json_is_tolerated(monkeypatch, tmp_path, capsys):

--- a/tests/test_visibility_events.py
+++ b/tests/test_visibility_events.py
@@ -777,6 +777,252 @@ def test_wrapper_tool_failure_recovered_by_later_tool_event_suppresses_signal(
     ]
 
 
+def test_wrapper_tool_failure_recovered_at_window_minus_one_suppresses_signal(
+    monkeypatch,
+):
+    class Clock:
+        now = 0.0
+
+        def monotonic(self):
+            return self.now
+
+    class AdvancingQueue:
+        def __init__(self, items: list[dict], clock: Clock):
+            self.items = list(items)
+            self.clock = clock
+
+        def get(self, timeout=None):
+            if self.items:
+                item = self.items.pop(0)
+                if "__advance__" in item:
+                    self.clock.now += float(item["__advance__"])
+                    raise RuntimeError("empty (test)")
+                return item
+            raise RuntimeError("empty (test)")
+
+    clock = Clock()
+    notifications = [
+        {
+            "method": "item/completed",
+            "params": {
+                "item": {
+                    "type": "mcpToolCall",
+                    "server": "claude_anyteam_wrapper",
+                    "tool": "task_update",
+                    "status": "failed",
+                    "error": "bad task id",
+                }
+            },
+        },
+        {"__advance__": 89},
+        {
+            "method": "item/completed",
+            "params": {
+                "item": {
+                    "type": "mcpToolCall",
+                    "server": "claude_anyteam_wrapper",
+                    "tool": "task_list",
+                    "status": "completed",
+                }
+            },
+        },
+        {"__advance__": 91},
+        {"method": "turn/completed", "params": {"turn": {"status": "ok"}}},
+    ]
+
+    class Client(_FakeClient):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, notifications=[], **kwargs)
+            self.notifications = AdvancingQueue(notifications, clock)
+
+    emitted: list[VisibilityEvent] = []
+    with (
+        patch.object(app_server_mod, "AppServerClient", Client),
+        monkeypatch.context() as m,
+    ):
+        m.setattr(codex_mod.time, "monotonic", clock.monotonic)
+        result = codex_mod.app_server_invoke(
+            task_prompt="recover just before the window closes",
+            cwd=Path("/tmp"),
+            schema=None,
+            settings_team="team-x",
+            settings_agent="codex-runtime",
+            task_id="49",
+            overall_timeout_s=900,
+            non_progress_warn_s=300,
+            wrapper_tool_failure_window_s=90,
+            event_sink=emitted.append,
+        )
+
+    assert result.exit_code == 0
+    assert not [
+        e for e in emitted if e.kind == "wrapper_tool_failure_unrecovered"
+    ]
+
+
+def test_wrapper_tool_failure_multi_failure_series_emits_one_terminal_envelope(
+    monkeypatch,
+):
+    class Clock:
+        now = 0.0
+
+        def monotonic(self):
+            return self.now
+
+    class AdvancingQueue:
+        def __init__(self, items: list[dict], clock: Clock):
+            self.items = list(items)
+            self.clock = clock
+
+        def get(self, timeout=None):
+            if self.items:
+                item = self.items.pop(0)
+                if "__advance__" in item:
+                    self.clock.now += float(item["__advance__"])
+                    raise RuntimeError("empty (test)")
+                return item
+            raise RuntimeError("empty (test)")
+
+    clock = Clock()
+
+    def failed_read(path: str) -> dict:
+        return {
+            "method": "item/completed",
+            "params": {
+                "item": {
+                    "type": "mcpToolCall",
+                    "server": "claude_anyteam_wrapper",
+                    "tool": "mcp_anyteam_read_file",
+                    "status": "failed",
+                    "error": f"[Errno 2] No such file or directory: {path!r}",
+                }
+            },
+        }
+
+    notifications = [
+        failed_read("/missing-1"),
+        {"__advance__": 1},
+        failed_read("/missing-2"),
+        {"__advance__": 1},
+        failed_read("/missing-3"),
+        {"__advance__": 91},
+        {"method": "turn/completed", "params": {"turn": {"status": "ok"}}},
+    ]
+
+    class Client(_FakeClient):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, notifications=[], **kwargs)
+            self.notifications = AdvancingQueue(notifications, clock)
+
+    emitted: list[VisibilityEvent] = []
+    with (
+        patch.object(app_server_mod, "AppServerClient", Client),
+        monkeypatch.context() as m,
+    ):
+        m.setattr(codex_mod.time, "monotonic", clock.monotonic)
+        result = codex_mod.app_server_invoke(
+            task_prompt="retry missing reads",
+            cwd=Path("/tmp"),
+            schema=None,
+            settings_team="team-x",
+            settings_agent="codex-runtime",
+            task_id="49",
+            overall_timeout_s=900,
+            non_progress_warn_s=300,
+            wrapper_tool_failure_window_s=90,
+            event_sink=emitted.append,
+        )
+
+    assert result.exit_code == 0
+    unrecovered = [
+        e for e in emitted if e.kind == "wrapper_tool_failure_unrecovered"
+    ]
+    assert len(unrecovered) == 1
+    failed_tool_events = [
+        e
+        for e in emitted
+        if e.kind == "tool_event" and e.severity == "error"
+    ]
+    assert len(failed_tool_events) == 3
+    assert unrecovered[0].payload["failed_event_seq"] == failed_tool_events[-1].seq
+    assert unrecovered[0].payload["tool_name"] == "mcp_anyteam_read_file"
+
+
+def test_wrapper_tool_failure_retry_loop_debounces_by_tool_name(monkeypatch):
+    class Clock:
+        now = 0.0
+
+        def monotonic(self):
+            return self.now
+
+    class AdvancingQueue:
+        def __init__(self, items: list[dict], clock: Clock):
+            self.items = list(items)
+            self.clock = clock
+
+        def get(self, timeout=None):
+            if self.items:
+                item = self.items.pop(0)
+                if "__advance__" in item:
+                    self.clock.now += float(item["__advance__"])
+                    raise RuntimeError("empty (test)")
+                return item
+            raise RuntimeError("empty (test)")
+
+    clock = Clock()
+    failed_update = {
+        "method": "item/completed",
+        "params": {
+            "item": {
+                "type": "mcpToolCall",
+                "server": "claude_anyteam_wrapper",
+                "tool": "task_update",
+                "status": "failed",
+                "error": "bad task id",
+            }
+        },
+    }
+    notifications = [
+        failed_update,
+        {"__advance__": 91},
+        failed_update,
+        {"__advance__": 91},
+        {"method": "turn/completed", "params": {"turn": {"status": "ok"}}},
+    ]
+
+    class Client(_FakeClient):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, notifications=[], **kwargs)
+            self.notifications = AdvancingQueue(notifications, clock)
+
+    emitted: list[VisibilityEvent] = []
+    with (
+        patch.object(app_server_mod, "AppServerClient", Client),
+        monkeypatch.context() as m,
+    ):
+        m.setattr(codex_mod.time, "monotonic", clock.monotonic)
+        result = codex_mod.app_server_invoke(
+            task_prompt="retry bad task updates",
+            cwd=Path("/tmp"),
+            schema=None,
+            settings_team="team-x",
+            settings_agent="codex-runtime",
+            task_id="49",
+            overall_timeout_s=900,
+            non_progress_warn_s=300,
+            wrapper_tool_failure_window_s=90,
+            event_sink=emitted.append,
+        )
+
+    assert result.exit_code == 0
+    unrecovered = [
+        e for e in emitted if e.kind == "wrapper_tool_failure_unrecovered"
+    ]
+    assert len(unrecovered) == 1
+    assert unrecovered[0].payload["tool_name"] == "task_update"
+    assert unrecovered[0].payload["debounced_by"] == "tool_name"
+
+
 
 def test_app_server_watchdog_fans_out_to_event_log_mailbox_and_active_form(
     events_root: Path,


### PR DESCRIPTION
Body-as-comment workaround for #58: see the first PR comment for the full summary, tests, and checklist.
