### PR TITLE
fix(#43 follow-up): env.py registration + bounded thresholds + subprocess_pressure aliases + CHANGELOG + test gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to claude-anyteam are documented here. Format follows [Keep 
 ### Added
 
 - **`wrapper_tool_failure_unrecovered` visibility envelope** (issue #49 / PR #60) surfaces Codex App Server wrapper-MCP tool failures that are not followed by `turn_progress`, `tool_event`, or `artifact_event` recovery activity within the discriminator window. The window is configurable with `--wrapper-tool-failure-window-s`, `CLAUDE_ANYTEAM_WRAPPER_TOOL_FAILURE_WINDOW_S`, and the per-teammate agents-file key `wrapper_tool_failure_window_s`.
+- **Codex sqlite WAL-bloat diagnostics/mitigation** (#43 / PR #54 follow-up): `claude-anyteam diagnose --codex-log-bloat` reports `logs_*.sqlite-wal` size pressure, and Codex App Server spawn now emits typed `visibility_degraded` events when WAL bloat is detected or checkpoint remediation cannot complete. Operator controls are centrally registered env vars:
+  - `CLAUDE_ANYTEAM_CODEX_SQLITE_WAL_WARN_THRESHOLD_BYTES` — warn threshold; default `104857600` bytes (100 MiB), bounded `[0, 10737418240]` (10 GiB).
+  - `CLAUDE_ANYTEAM_CODEX_SQLITE_WAL_CHECKPOINT` — enable/disable the pre-spawn sqlite checkpoint attempt; default enabled (set `0`, `false`, `no`, `off`, or `disabled` to skip).
+  - `CLAUDE_ANYTEAM_CODEX_SQLITE_WAL_CHECKPOINT_TIMEOUT_S` — checkpoint timeout budget; default `10s`, bounded `[0.001, 60]`; the same budget caps the aggregate time spent across all bloated WALs.
 
 ### Changed
 

--- a/src/claude_anyteam/codex.py
+++ b/src/claude_anyteam/codex.py
@@ -1724,6 +1724,16 @@ def app_server_invoke(
     def _codex_log_bloat_pre_spawn() -> None:
         """Emit #43 pre-spawn visibility and run a bounded WAL checkpoint."""
 
+        pressure_alias_payload = {
+            "pressure_source": "sqlite_wal_bloat",
+            "remediation": "bounded_checkpoint_before_spawn",
+            "hint": (
+                "Run `claude-anyteam diagnose --codex-log-bloat`; if no Codex "
+                "process is running and checkpointing still fails, back up then "
+                "move/remove the matching logs_*.sqlite* files."
+            ),
+        }
+
         try:
             report = inspect_codex_log_bloat(env=os.environ)
         except Exception as e:
@@ -1750,6 +1760,7 @@ def app_server_invoke(
                 "surface": "codex_sqlite_wal_bloat",
                 "action": "bounded_checkpoint_before_spawn",
                 "diagnose_command": "claude-anyteam diagnose --codex-log-bloat",
+                **pressure_alias_payload,
                 **report_payload,
             },
         )
@@ -1763,15 +1774,15 @@ def app_server_invoke(
             return
         checkpoint_payload = {
             "surface": "codex_sqlite_wal_checkpoint",
+            **pressure_alias_payload,
             "results": [row.to_dict() for row in checkpoint_results],
         }
-        all_ok = all(row.ok for row in checkpoint_results if row.attempted)
-        any_attempted = any(row.attempted for row in checkpoint_results)
-        if not any_attempted:
+        if all(row.status == "disabled" for row in checkpoint_results):
             return
+        all_ok = all(row.ok for row in checkpoint_results)
         if all_ok:
             _emit_visibility_event(
-                kind="turn_progress",
+                kind="visibility_degraded",
                 severity="info",
                 summary="Codex sqlite WAL checkpoint completed before spawn",
                 visibility={
@@ -1791,7 +1802,7 @@ def app_server_invoke(
                     "App Server spawn"
                 ),
                 visibility={
-                    "mailbox": False,
+                    "mailbox": True,
                     "task_state": False,
                     "event_log": True,
                     "stderr": True,

--- a/src/claude_anyteam/codex_log_bloat.py
+++ b/src/claude_anyteam/codex_log_bloat.py
@@ -20,19 +20,21 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping
 
+from .env import (
+    CODEX_WAL_CHECKPOINT_ENV,
+    CODEX_WAL_CHECKPOINT_TIMEOUT_ENV,
+    CODEX_WAL_WARN_THRESHOLD_BYTES_ENV,
+)
+
 CODEX_HOME_ENV = "CODEX_HOME"
 CODEX_SQLITE_HOME_ENV = "CODEX_SQLITE_HOME"
 
-CODEX_WAL_WARN_THRESHOLD_BYTES_ENV = (
-    "CLAUDE_ANYTEAM_CODEX_SQLITE_WAL_WARN_THRESHOLD_BYTES"
-)
-CODEX_WAL_CHECKPOINT_ENV = "CLAUDE_ANYTEAM_CODEX_SQLITE_WAL_CHECKPOINT"
-CODEX_WAL_CHECKPOINT_TIMEOUT_ENV = (
-    "CLAUDE_ANYTEAM_CODEX_SQLITE_WAL_CHECKPOINT_TIMEOUT_S"
-)
-
 DEFAULT_CODEX_WAL_WARN_THRESHOLD_BYTES = 100 * 1024 * 1024
+MIN_CODEX_WAL_WARN_THRESHOLD_BYTES = 0
+MAX_CODEX_WAL_WARN_THRESHOLD_BYTES = 10 * 1024 * 1024 * 1024
 DEFAULT_CODEX_WAL_CHECKPOINT_TIMEOUT_S = 10.0
+MIN_CODEX_WAL_CHECKPOINT_TIMEOUT_S = 0.001
+MAX_CODEX_WAL_CHECKPOINT_TIMEOUT_S = 60.0
 LOGS_WAL_GLOB = "logs_*.sqlite-wal"
 
 _FALSEY = {"0", "false", "no", "off", "disabled"}
@@ -152,26 +154,48 @@ def _truthy_env_enabled(env: Mapping[str, str], name: str, *, default: bool) -> 
     return raw.strip().lower() not in _FALSEY
 
 
-def _int_env(env: Mapping[str, str], name: str, default: int) -> int:
+def _bounded_int_env(
+    env: Mapping[str, str],
+    name: str,
+    default: int,
+    *,
+    min_value: int,
+    max_value: int,
+) -> int:
     raw = env.get(name)
     if raw is None or raw == "":
         return default
     try:
         value = int(raw)
-    except ValueError:
-        return default
-    return max(0, value)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be an integer, got {raw!r}") from exc
+    if not (min_value <= value <= max_value):
+        raise ValueError(
+            f"{name} must be in [{min_value}, {max_value}], got {value}"
+        )
+    return value
 
 
-def _float_env(env: Mapping[str, str], name: str, default: float) -> float:
+def _bounded_float_env(
+    env: Mapping[str, str],
+    name: str,
+    default: float,
+    *,
+    min_value: float,
+    max_value: float,
+) -> float:
     raw = env.get(name)
     if raw is None or raw == "":
         return default
     try:
         value = float(raw)
-    except ValueError:
-        return default
-    return max(0.001, value)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be numeric, got {raw!r}") from exc
+    if not (min_value <= value <= max_value):
+        raise ValueError(
+            f"{name} must be in [{min_value:g}, {max_value:g}] seconds, got {value}"
+        )
+    return value
 
 
 def codex_sqlite_home(
@@ -202,10 +226,12 @@ def codex_sqlite_home(
 
 def codex_wal_warn_threshold_bytes(env: Mapping[str, str] | None = None) -> int:
     env_map = env if env is not None else os.environ
-    return _int_env(
+    return _bounded_int_env(
         env_map,
         CODEX_WAL_WARN_THRESHOLD_BYTES_ENV,
         DEFAULT_CODEX_WAL_WARN_THRESHOLD_BYTES,
+        min_value=MIN_CODEX_WAL_WARN_THRESHOLD_BYTES,
+        max_value=MAX_CODEX_WAL_WARN_THRESHOLD_BYTES,
     )
 
 
@@ -222,11 +248,20 @@ def inspect_codex_log_bloat(
         sqlite_home, source = codex_sqlite_home(env_map)
     else:
         source = "explicit"
-    threshold = (
-        codex_wal_warn_threshold_bytes(env_map)
-        if threshold_bytes is None
-        else max(0, int(threshold_bytes))
-    )
+    if threshold_bytes is None:
+        threshold = codex_wal_warn_threshold_bytes(env_map)
+    else:
+        threshold = int(threshold_bytes)
+        if not (
+            MIN_CODEX_WAL_WARN_THRESHOLD_BYTES
+            <= threshold
+            <= MAX_CODEX_WAL_WARN_THRESHOLD_BYTES
+        ):
+            raise ValueError(
+                "threshold_bytes must be in "
+                f"[{MIN_CODEX_WAL_WARN_THRESHOLD_BYTES}, "
+                f"{MAX_CODEX_WAL_WARN_THRESHOLD_BYTES}], got {threshold}"
+            )
     rows: list[CodexWalFile] = []
     try:
         paths = sorted(sqlite_home.glob(LOGS_WAL_GLOB))
@@ -390,18 +425,47 @@ def checkpoint_bloated_codex_wals(
             for wal in report.bloated_wal_files
         )
     budget = (
-        _float_env(
+        _bounded_float_env(
             env_map,
             CODEX_WAL_CHECKPOINT_TIMEOUT_ENV,
             DEFAULT_CODEX_WAL_CHECKPOINT_TIMEOUT_S,
+            min_value=MIN_CODEX_WAL_CHECKPOINT_TIMEOUT_S,
+            max_value=MAX_CODEX_WAL_CHECKPOINT_TIMEOUT_S,
         )
         if timeout_s is None
-        else max(0.001, timeout_s)
+        else float(timeout_s)
     )
-    return tuple(
-        checkpoint_codex_wal(wal, timeout_s=budget)
-        for wal in report.bloated_wal_files
-    )
+    if not (
+        MIN_CODEX_WAL_CHECKPOINT_TIMEOUT_S
+        <= budget
+        <= MAX_CODEX_WAL_CHECKPOINT_TIMEOUT_S
+    ):
+        raise ValueError(
+            "timeout_s must be in "
+            f"[{MIN_CODEX_WAL_CHECKPOINT_TIMEOUT_S:g}, "
+            f"{MAX_CODEX_WAL_CHECKPOINT_TIMEOUT_S:g}] seconds, got {budget}"
+        )
+
+    deadline = time.monotonic() + budget
+    results: list[CodexWalCheckpointResult] = []
+    for wal in report.bloated_wal_files:
+        remaining_s = deadline - time.monotonic()
+        if remaining_s <= 0:
+            results.append(
+                CodexWalCheckpointResult(
+                    wal_path=wal.path,
+                    database_path=wal.database_path,
+                    attempted=False,
+                    status="timeout",
+                    error=(
+                        "aggregate Codex WAL checkpoint timeout exhausted "
+                        f"after {budget:g}s"
+                    ),
+                )
+            )
+            continue
+        results.append(checkpoint_codex_wal(wal, timeout_s=min(budget, remaining_s)))
+    return tuple(results)
 
 
 def format_bytes(num_bytes: int | None) -> str:

--- a/src/claude_anyteam/env.py
+++ b/src/claude_anyteam/env.py
@@ -47,6 +47,17 @@ LEGACY_NON_PROGRESS_INTERRUPT_ENV = "CODEX_TEAMMATE_NON_PROGRESS_INTERRUPT_S"
 
 WRAPPER_TOOL_FAILURE_WINDOW_ENV = "CLAUDE_ANYTEAM_WRAPPER_TOOL_FAILURE_WINDOW_S"
 
+# Codex CLI sqlite WAL-bloat mitigation (#43). These are claude-anyteam-owned
+# controls for warning on large ``logs_*.sqlite-wal`` files and attempting a
+# bounded sqlite checkpoint before spawning Codex App Server.
+CODEX_WAL_WARN_THRESHOLD_BYTES_ENV = (
+    "CLAUDE_ANYTEAM_CODEX_SQLITE_WAL_WARN_THRESHOLD_BYTES"
+)
+CODEX_WAL_CHECKPOINT_ENV = "CLAUDE_ANYTEAM_CODEX_SQLITE_WAL_CHECKPOINT"
+CODEX_WAL_CHECKPOINT_TIMEOUT_ENV = (
+    "CLAUDE_ANYTEAM_CODEX_SQLITE_WAL_CHECKPOINT_TIMEOUT_S"
+)
+
 # Codex App Server JSON-RPC ``initialize`` budget (#40 Phase 1).
 # Default 90s — chosen because the only successful empirical sample we
 # have (codex-reviewer turn 1, parking-ack prompt, ~17s) is well under

--- a/tests/test_codex_log_bloat.py
+++ b/tests/test_codex_log_bloat.py
@@ -8,13 +8,22 @@ import sqlite3
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from claude_anyteam import app_server as app_server_mod
 from claude_anyteam import codex as codex_mod
+from claude_anyteam import codex_log_bloat as bloat_mod
 from claude_anyteam import diagnose_cli
 from claude_anyteam.codex_log_bloat import (
     CODEX_WAL_CHECKPOINT_ENV,
+    CODEX_WAL_CHECKPOINT_TIMEOUT_ENV,
     CODEX_WAL_WARN_THRESHOLD_BYTES_ENV,
+    MAX_CODEX_WAL_CHECKPOINT_TIMEOUT_S,
+    MAX_CODEX_WAL_WARN_THRESHOLD_BYTES,
     CodexWalFile,
+    CodexLogBloatReport,
+    CodexWalCheckpointResult,
+    checkpoint_bloated_codex_wals,
     checkpoint_codex_wal,
     inspect_codex_log_bloat,
 )
@@ -26,6 +35,84 @@ def _make_sparse_wal(root: Path, *, size_bytes: int, name: str = "logs_2") -> Pa
     with wal.open("wb") as fh:
         fh.truncate(size_bytes)
     return wal
+
+
+def _invoke_app_server_with_bloat(tmp_path: Path, captured: list) -> codex_mod.CodexResult:
+    class _Queue:
+        def __init__(self) -> None:
+            self._items = [
+                {"method": "turn/completed", "params": {"turn": {"status": "ok"}}}
+            ]
+
+        def get(self, timeout=None):
+            if self._items:
+                return self._items.pop(0)
+            raise RuntimeError("empty (test)")
+
+    class _FakeClient:
+        notifications = _Queue()
+
+        def __init__(self, *args, pre_start_hook=None, **kwargs) -> None:
+            self._pre_start_hook = pre_start_hook
+            self.notifications = _Queue()
+
+        def start(self) -> None:
+            if self._pre_start_hook is not None:
+                self._pre_start_hook()
+
+        def initialize(self, **_kwargs):
+            return {}
+
+        def thread_start(self, **kwargs):
+            return "thread-id"
+
+        def turn_start(self, **kwargs):
+            return "turn-id"
+
+        def drain_notifications(self):
+            return []
+
+        def turn_interrupt(self, **kwargs):
+            pass
+
+        def close(self, **kwargs):
+            pass
+
+    with patch.object(app_server_mod, "AppServerClient", _FakeClient):
+        return codex_mod.app_server_invoke(
+            task_prompt="noop",
+            cwd=tmp_path,
+            schema=None,
+            settings_team="team",
+            settings_agent="codex-a",
+            event_sink=captured.append,
+        )
+
+
+def _bloated_report(tmp_path: Path, *, count: int = 1) -> CodexLogBloatReport:
+    rows: list[CodexWalFile] = []
+    for index in range(count):
+        wal_path = _make_sparse_wal(
+            tmp_path,
+            size_bytes=2 * 1024 * 1024,
+            name=f"logs_{index}",
+        )
+        database_path = Path(str(wal_path)[:-4])
+        database_path.write_bytes(b"sqlite placeholder")
+        rows.append(
+            CodexWalFile(
+                path=wal_path,
+                size_bytes=wal_path.stat().st_size,
+                threshold_bytes=1,
+                database_path=database_path,
+            )
+        )
+    return CodexLogBloatReport(
+        sqlite_home=tmp_path,
+        sqlite_home_source="explicit",
+        threshold_bytes=1,
+        wal_files=tuple(rows),
+    )
 
 
 def test_wal_size_check_flags_sparse_200mb_repro(tmp_path: Path) -> None:
@@ -54,6 +141,30 @@ def test_threshold_env_controls_bloat_boundary(tmp_path: Path, monkeypatch) -> N
     monkeypatch.setenv(CODEX_WAL_WARN_THRESHOLD_BYTES_ENV, str(1024 * 1024))
     above = inspect_codex_log_bloat(sqlite_home=tmp_path)
     assert above.is_bloated is True
+
+
+def test_threshold_env_rejects_out_of_range_values(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv(
+        CODEX_WAL_WARN_THRESHOLD_BYTES_ENV,
+        str(MAX_CODEX_WAL_WARN_THRESHOLD_BYTES + 1),
+    )
+
+    with pytest.raises(ValueError, match=CODEX_WAL_WARN_THRESHOLD_BYTES_ENV):
+        inspect_codex_log_bloat(sqlite_home=tmp_path)
+
+
+def test_checkpoint_timeout_env_rejects_out_of_range_values(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    report = _bloated_report(tmp_path)
+    monkeypatch.setenv(
+        CODEX_WAL_CHECKPOINT_TIMEOUT_ENV,
+        str(MAX_CODEX_WAL_CHECKPOINT_TIMEOUT_S + 1),
+    )
+
+    with pytest.raises(ValueError, match=CODEX_WAL_CHECKPOINT_TIMEOUT_ENV):
+        checkpoint_bloated_codex_wals(report)
 
 
 def test_diagnose_codex_log_bloat_subcommand_flags_large_wal(tmp_path: Path) -> None:
@@ -128,6 +239,146 @@ def test_checkpoint_path_truncates_real_sqlite_wal(tmp_path: Path) -> None:
     assert (not wal_path.exists()) or wal_path.stat().st_size == 0
 
 
+def test_checkpoint_path_reports_missing_db(tmp_path: Path) -> None:
+    wal_path = _make_sparse_wal(tmp_path, size_bytes=1024)
+
+    result = checkpoint_codex_wal(
+        CodexWalFile(
+            path=wal_path,
+            size_bytes=wal_path.stat().st_size,
+            threshold_bytes=1,
+            database_path=tmp_path / "logs_2.sqlite",
+        )
+    )
+
+    assert result.attempted is False
+    assert result.status == "missing_db"
+    assert "database file not found" in (result.error or "")
+
+
+def test_checkpoint_path_reports_busy_from_sqlite_result(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    report = _bloated_report(tmp_path)
+
+    class _Cursor:
+        def fetchone(self):
+            return (1, 12, 4)
+
+    class _Connection:
+        def execute(self, sql):
+            if sql == "PRAGMA wal_checkpoint(TRUNCATE)":
+                return _Cursor()
+            return _Cursor()
+
+        def set_progress_handler(self, callback, n):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(bloat_mod.sqlite3, "connect", lambda *a, **kw: _Connection())
+
+    result = checkpoint_codex_wal(report.bloated_wal_files[0], timeout_s=1)
+
+    assert result.attempted is True
+    assert result.status == "busy"
+    assert result.busy == 1
+    assert result.log_frames == 12
+    assert result.checkpointed_frames == 4
+
+
+def test_checkpoint_path_reports_timeout_from_progress_interrupt(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    report = _bloated_report(tmp_path)
+
+    class _Connection:
+        def execute(self, sql):
+            if sql == "PRAGMA wal_checkpoint(TRUNCATE)":
+                raise sqlite3.OperationalError("interrupted")
+            return self
+
+        def set_progress_handler(self, callback, n):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(bloat_mod.sqlite3, "connect", lambda *a, **kw: _Connection())
+
+    result = checkpoint_codex_wal(report.bloated_wal_files[0], timeout_s=1)
+
+    assert result.attempted is True
+    assert result.status == "timeout"
+    assert "interrupted" in (result.error or "")
+
+
+def test_checkpoint_path_reports_error_from_sqlite_operational_error(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    report = _bloated_report(tmp_path)
+
+    class _Connection:
+        def execute(self, sql):
+            if sql == "PRAGMA wal_checkpoint(TRUNCATE)":
+                raise sqlite3.OperationalError("disk I/O error")
+            return self
+
+        def set_progress_handler(self, callback, n):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(bloat_mod.sqlite3, "connect", lambda *a, **kw: _Connection())
+
+    result = checkpoint_codex_wal(report.bloated_wal_files[0], timeout_s=1)
+
+    assert result.attempted is True
+    assert result.status == "error"
+    assert "disk I/O error" in (result.error or "")
+
+
+def test_checkpoint_bloated_codex_wals_caps_aggregate_timeout(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    report = _bloated_report(tmp_path, count=3)
+    now = 100.0
+    calls: list[float] = []
+
+    def fake_monotonic() -> float:
+        return now
+
+    def fake_checkpoint(wal: CodexWalFile, *, timeout_s: float):
+        nonlocal now
+        calls.append(timeout_s)
+        now += timeout_s + 0.001
+        return CodexWalCheckpointResult(
+            wal_path=wal.path,
+            database_path=wal.database_path,
+            attempted=True,
+            status="checkpointed",
+        )
+
+    monkeypatch.setattr(bloat_mod.time, "monotonic", fake_monotonic)
+    monkeypatch.setattr(bloat_mod, "checkpoint_codex_wal", fake_checkpoint)
+
+    results = checkpoint_bloated_codex_wals(
+        report,
+        enabled=True,
+        timeout_s=0.01,
+    )
+
+    assert calls == [pytest.approx(0.01)]
+    assert [row.status for row in results] == ["checkpointed", "timeout", "timeout"]
+    assert [row.attempted for row in results] == [True, False, False]
+
+
 def test_pre_spawn_warning_emits_visibility_degraded_before_initialize(
     tmp_path: Path,
     monkeypatch,
@@ -140,55 +391,7 @@ def test_pre_spawn_warning_emits_visibility_degraded_before_initialize(
 
     captured = []
 
-    class _Queue:
-        def __init__(self) -> None:
-            self._items = [
-                {"method": "turn/completed", "params": {"turn": {"status": "ok"}}}
-            ]
-
-        def get(self, timeout=None):
-            if self._items:
-                return self._items.pop(0)
-            raise RuntimeError("empty (test)")
-
-    class _FakeClient:
-        notifications = _Queue()
-
-        def __init__(self, *args, pre_start_hook=None, **kwargs) -> None:
-            self._pre_start_hook = pre_start_hook
-            self.notifications = _Queue()
-
-        def start(self) -> None:
-            if self._pre_start_hook is not None:
-                self._pre_start_hook()
-
-        def initialize(self, **_kwargs):
-            return {}
-
-        def thread_start(self, **kwargs):
-            return "thread-id"
-
-        def turn_start(self, **kwargs):
-            return "turn-id"
-
-        def drain_notifications(self):
-            return []
-
-        def turn_interrupt(self, **kwargs):
-            pass
-
-        def close(self, **kwargs):
-            pass
-
-    with patch.object(app_server_mod, "AppServerClient", _FakeClient):
-        result = codex_mod.app_server_invoke(
-            task_prompt="noop",
-            cwd=tmp_path,
-            schema=None,
-            settings_team="team",
-            settings_agent="codex-a",
-            event_sink=captured.append,
-        )
+    result = _invoke_app_server_with_bloat(tmp_path, captured)
 
     assert result.exit_code == 0
     surfaces = [event.payload.get("surface") for event in captured]
@@ -197,7 +400,94 @@ def test_pre_spawn_warning_emits_visibility_degraded_before_initialize(
     assert warning.kind == "visibility_degraded"
     assert warning.severity == "warn"
     assert warning.payload["max_wal_bytes"] == 200 * 1024 * 1024
+    assert warning.payload["pressure_source"] == "sqlite_wal_bloat"
+    assert warning.payload["remediation"] == "bounded_checkpoint_before_spawn"
+    assert "diagnose --codex-log-bloat" in warning.payload["hint"]
     completed_index = next(
         i for i, event in enumerate(captured) if event.kind == "app_server_initialize_completed"
     )
     assert completed_index > 0
+
+
+def test_pre_spawn_checkpoint_success_uses_visibility_degraded_info(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _make_sparse_wal(tmp_path, size_bytes=200 * 1024 * 1024)
+    monkeypatch.setenv("CODEX_SQLITE_HOME", str(tmp_path))
+
+    def fake_checkpoint(report, *, env):
+        wal = report.bloated_wal_files[0]
+        return (
+            CodexWalCheckpointResult(
+                wal_path=wal.path,
+                database_path=wal.database_path,
+                attempted=True,
+                status="checkpointed",
+            ),
+        )
+
+    monkeypatch.setattr(codex_mod, "checkpoint_bloated_codex_wals", fake_checkpoint)
+    captured = []
+
+    result = _invoke_app_server_with_bloat(tmp_path, captured)
+
+    assert result.exit_code == 0
+    checkpoint = next(
+        event
+        for event in captured
+        if event.payload.get("surface") == "codex_sqlite_wal_checkpoint"
+    )
+    assert checkpoint.kind == "visibility_degraded"
+    assert checkpoint.severity == "info"
+    assert checkpoint.visibility.mailbox is False
+    assert checkpoint.payload["pressure_source"] == "sqlite_wal_bloat"
+    assert checkpoint.payload["results"][0]["status"] == "checkpointed"
+
+
+@pytest.mark.parametrize(
+    ("status", "attempted"),
+    [
+        ("busy", True),
+        ("timeout", True),
+        ("error", True),
+        ("missing_db", False),
+    ],
+)
+def test_pre_spawn_checkpoint_failures_are_mailbox_actionable(
+    tmp_path: Path,
+    monkeypatch,
+    status: str,
+    attempted: bool,
+) -> None:
+    _make_sparse_wal(tmp_path, size_bytes=200 * 1024 * 1024)
+    monkeypatch.setenv("CODEX_SQLITE_HOME", str(tmp_path))
+
+    def fake_checkpoint(report, *, env):
+        wal = report.bloated_wal_files[0]
+        return (
+            CodexWalCheckpointResult(
+                wal_path=wal.path,
+                database_path=wal.database_path,
+                attempted=attempted,
+                status=status,
+                error=f"simulated {status}",
+            ),
+        )
+
+    monkeypatch.setattr(codex_mod, "checkpoint_bloated_codex_wals", fake_checkpoint)
+    captured = []
+
+    result = _invoke_app_server_with_bloat(tmp_path, captured)
+
+    assert result.exit_code == 0
+    checkpoint = next(
+        event
+        for event in captured
+        if event.payload.get("surface") == "codex_sqlite_wal_checkpoint"
+    )
+    assert checkpoint.kind == "visibility_degraded"
+    assert checkpoint.severity == "warn"
+    assert checkpoint.visibility.mailbox is True
+    assert checkpoint.payload["pressure_source"] == "sqlite_wal_bloat"
+    assert checkpoint.payload["results"][0]["status"] == status


### PR DESCRIPTION
## Summary
- Centralize the three Codex sqlite WAL-bloat env var names in `env.py` and add explicit bounds/ValueError behavior for the numeric WAL threshold/timeout knobs.
- Add `pressure_source`, `remediation`, and `hint` aliases to WAL-bloat visibility payloads for the future `subprocess_pressure` kind, switch checkpoint success to `visibility_degraded`/`info`, and make checkpoint failures mailbox-visible.
- Cap aggregate checkpoint time across all bloated WALs, document `--codex-log-bloat` + env defaults in CHANGELOG, and add tests for busy/timeout/error/missing_db failure branches.

## Tests
- `uv run pytest tests/test_codex_log_bloat.py -q`
- `uv run pytest -q`

Reviewer ping: opus-reviewer
